### PR TITLE
Fix overlay_control and quick_list bg and fg styling

### DIFF
--- a/base16-3024.sublime-theme
+++ b/base16-3024.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3a3432",
+    "layer1.tint": "#5c5855",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5c5855",
+    "layer2.tint": "#4a4543",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5c5855",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5c5855",
+    "layer0.tint": "#4a4543",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a5a2a23f",
+    "layer0.tint": "#5c58553f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d6d5d4",
     "match_fg": "#fded02",
-    "selected_fg": "#807d7c",
+    "selected_fg": "#f7f7f7",
     "selected_match_fg": "#fded02"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d6d5d4",
     "match_fg": "#fded02",
-    "selected_fg": "#807d7c",
+    "selected_fg": "#f7f7f7",
     "selected_match_fg": "#fded02"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d6d5d4",
-    "match_fg": "#a5a2a2",
-    "selected_fg": "#807d7c",
-    "selected_match_fg": "#807d7c"
+    "fg": "#807d7c",
+    "match_fg": "#fded02",
+    "selected_fg": "#a5a2a2",
+    "selected_match_fg": "#fded02"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5c5855",
+    "layer0.tint": "#4a4543",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d6d5d4",
     "match_fg": "#fded02",
-    "selected_fg": "transparent",
+    "selected_fg": "#f7f7f7",
     "selected_match_fg": "#fded02",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#090300",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4a4543",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4a4543",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5c5855",
+    "layer0.tint": "#4a4543",
+    "color_scheme_tint": "#4a4543",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-apathy.sublime-theme
+++ b/base16-apathy.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#0b342d",
+    "layer1.tint": "#2b685e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#2b685e",
+    "layer2.tint": "#184e45",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#2b685e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#2b685e",
+    "layer0.tint": "#184e45",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#81b5ac3f",
+    "layer0.tint": "#2b685e3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#a7cec8",
     "match_fg": "#3e4c96",
-    "selected_fg": "#5f9c92",
+    "selected_fg": "#d2e7e4",
     "selected_match_fg": "#3e4c96"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#a7cec8",
     "match_fg": "#3e4c96",
-    "selected_fg": "#5f9c92",
+    "selected_fg": "#d2e7e4",
     "selected_match_fg": "#3e4c96"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#a7cec8",
-    "match_fg": "#81b5ac",
-    "selected_fg": "#5f9c92",
-    "selected_match_fg": "#5f9c92"
+    "fg": "#5f9c92",
+    "match_fg": "#3e4c96",
+    "selected_fg": "#81b5ac",
+    "selected_match_fg": "#3e4c96"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#2b685e",
+    "layer0.tint": "#184e45",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#a7cec8",
     "match_fg": "#3e4c96",
-    "selected_fg": "transparent",
+    "selected_fg": "#d2e7e4",
     "selected_match_fg": "#3e4c96",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#031a16",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#184e45",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#184e45",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#2b685e",
+    "layer0.tint": "#184e45",
+    "color_scheme_tint": "#184e45",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-apprentice.sublime-theme
+++ b/base16-apprentice.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#af5f5f",
+    "layer1.tint": "#87875f",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#87875f",
+    "layer2.tint": "#5f875f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#87875f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#87875f",
+    "layer0.tint": "#5f875f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5f5f873f",
+    "layer0.tint": "#87875f3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#5f8787",
     "match_fg": "#87af87",
-    "selected_fg": "#5f87af",
+    "selected_fg": "#6c6c6c",
     "selected_match_fg": "#87af87"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#5f8787",
     "match_fg": "#87af87",
-    "selected_fg": "#5f87af",
+    "selected_fg": "#6c6c6c",
     "selected_match_fg": "#87af87"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#5f8787",
-    "match_fg": "#5f5f87",
-    "selected_fg": "#5f87af",
-    "selected_match_fg": "#5f87af"
+    "fg": "#5f87af",
+    "match_fg": "#87af87",
+    "selected_fg": "#5f5f87",
+    "selected_match_fg": "#87af87"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#87875f",
+    "layer0.tint": "#5f875f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#5f8787",
     "match_fg": "#87af87",
-    "selected_fg": "transparent",
+    "selected_fg": "#6c6c6c",
     "selected_match_fg": "#87af87",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#262626",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5f875f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5f875f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#87875f",
+    "layer0.tint": "#5f875f",
+    "color_scheme_tint": "#5f875f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-ashes.sublime-theme
+++ b/base16-ashes.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#393f45",
+    "layer1.tint": "#747c84",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#747c84",
+    "layer2.tint": "#565e65",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#747c84",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#747c84",
+    "layer0.tint": "#565e65",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c7ccd13f",
+    "layer0.tint": "#747c843f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dfe2e5",
     "match_fg": "#aec795",
-    "selected_fg": "#adb3ba",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#aec795"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dfe2e5",
     "match_fg": "#aec795",
-    "selected_fg": "#adb3ba",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#aec795"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dfe2e5",
-    "match_fg": "#c7ccd1",
-    "selected_fg": "#adb3ba",
-    "selected_match_fg": "#adb3ba"
+    "fg": "#adb3ba",
+    "match_fg": "#aec795",
+    "selected_fg": "#c7ccd1",
+    "selected_match_fg": "#aec795"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#747c84",
+    "layer0.tint": "#565e65",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dfe2e5",
     "match_fg": "#aec795",
-    "selected_fg": "transparent",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#aec795",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1c2023",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#565e65",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#565e65",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#747c84",
+    "layer0.tint": "#565e65",
+    "color_scheme_tint": "#565e65",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-cave-light.sublime-theme
+++ b/base16-atelier-cave-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#8b8792",
+    "layer0.tint": "#7e7887",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e2dfe71e",
+    "layer1.tint": "#7e7887",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7e7887",
+    "layer2.tint": "#8b8792",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7e7887",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7e7887",
+    "layer0.tint": "#8b8792",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5852601e",
+    "layer0.tint": "#7e78871e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#26232a",
+    "fg": "#585260",
     "match_fg": "#a06e3b",
-    "selected_fg": "#655f6d",
+    "selected_fg": "#585260",
     "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#26232a",
+    "fg": "#585260",
     "match_fg": "#a06e3b",
-    "selected_fg": "#655f6d",
+    "selected_fg": "#585260",
     "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#26232a",
-    "match_fg": "#585260",
-    "selected_fg": "#655f6d",
-    "selected_match_fg": "#655f6d"
+    "fg": "#655f6d",
+    "match_fg": "#a06e3b",
+    "selected_fg": "#585260",
+    "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7e7887",
+    "layer0.tint": "#8b8792",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#26232a",
     "match_fg": "#a06e3b",
-    "selected_fg": "transparent",
+    "selected_fg": "#19171c",
     "selected_match_fg": "#a06e3b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#efecf4",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#8b8792",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#8b8792",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7e7887",
+    "layer0.tint": "#8b8792",
+    "color_scheme_tint": "#8b8792",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-cave.sublime-theme
+++ b/base16-atelier-cave.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#26232a",
+    "layer1.tint": "#655f6d",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#655f6d",
+    "layer2.tint": "#585260",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#655f6d",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#655f6d",
+    "layer0.tint": "#585260",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8b87923f",
+    "layer0.tint": "#655f6d3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e2dfe7",
     "match_fg": "#a06e3b",
-    "selected_fg": "#7e7887",
+    "selected_fg": "#efecf4",
     "selected_match_fg": "#a06e3b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e2dfe7",
     "match_fg": "#a06e3b",
-    "selected_fg": "#7e7887",
+    "selected_fg": "#efecf4",
     "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e2dfe7",
-    "match_fg": "#8b8792",
-    "selected_fg": "#7e7887",
-    "selected_match_fg": "#7e7887"
+    "fg": "#7e7887",
+    "match_fg": "#a06e3b",
+    "selected_fg": "#8b8792",
+    "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#655f6d",
+    "layer0.tint": "#585260",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e2dfe7",
     "match_fg": "#a06e3b",
-    "selected_fg": "transparent",
+    "selected_fg": "#efecf4",
     "selected_match_fg": "#a06e3b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#19171c",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#585260",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#585260",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#655f6d",
+    "layer0.tint": "#585260",
+    "color_scheme_tint": "#585260",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-dune-light.sublime-theme
+++ b/base16-atelier-dune-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#a6a28c",
+    "layer0.tint": "#999580",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e8e4cf1e",
+    "layer1.tint": "#999580",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#999580",
+    "layer2.tint": "#a6a28c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#999580",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#999580",
+    "layer0.tint": "#a6a28c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#6e6b5e1e",
+    "layer0.tint": "#9995801e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#292824",
+    "fg": "#6e6b5e",
     "match_fg": "#ae9513",
-    "selected_fg": "#7d7a68",
+    "selected_fg": "#6e6b5e",
     "selected_match_fg": "#ae9513"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#292824",
+    "fg": "#6e6b5e",
     "match_fg": "#ae9513",
-    "selected_fg": "#7d7a68",
+    "selected_fg": "#6e6b5e",
     "selected_match_fg": "#ae9513"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#292824",
-    "match_fg": "#6e6b5e",
-    "selected_fg": "#7d7a68",
-    "selected_match_fg": "#7d7a68"
+    "fg": "#7d7a68",
+    "match_fg": "#ae9513",
+    "selected_fg": "#6e6b5e",
+    "selected_match_fg": "#ae9513"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#999580",
+    "layer0.tint": "#a6a28c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#292824",
     "match_fg": "#ae9513",
-    "selected_fg": "transparent",
+    "selected_fg": "#20201d",
     "selected_match_fg": "#ae9513",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fefbec",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#a6a28c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#a6a28c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#999580",
+    "layer0.tint": "#a6a28c",
+    "color_scheme_tint": "#a6a28c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-dune.sublime-theme
+++ b/base16-atelier-dune.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#292824",
+    "layer1.tint": "#7d7a68",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7d7a68",
+    "layer2.tint": "#6e6b5e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7d7a68",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7d7a68",
+    "layer0.tint": "#6e6b5e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a6a28c3f",
+    "layer0.tint": "#7d7a683f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e4cf",
     "match_fg": "#ae9513",
-    "selected_fg": "#999580",
+    "selected_fg": "#fefbec",
     "selected_match_fg": "#ae9513"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e4cf",
     "match_fg": "#ae9513",
-    "selected_fg": "#999580",
+    "selected_fg": "#fefbec",
     "selected_match_fg": "#ae9513"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e4cf",
-    "match_fg": "#a6a28c",
-    "selected_fg": "#999580",
-    "selected_match_fg": "#999580"
+    "fg": "#999580",
+    "match_fg": "#ae9513",
+    "selected_fg": "#a6a28c",
+    "selected_match_fg": "#ae9513"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7d7a68",
+    "layer0.tint": "#6e6b5e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e4cf",
     "match_fg": "#ae9513",
-    "selected_fg": "transparent",
+    "selected_fg": "#fefbec",
     "selected_match_fg": "#ae9513",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#20201d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#6e6b5e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#6e6b5e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7d7a68",
+    "layer0.tint": "#6e6b5e",
+    "color_scheme_tint": "#6e6b5e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-estuary-light.sublime-theme
+++ b/base16-atelier-estuary-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#929181",
+    "layer0.tint": "#878573",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e7e6df1e",
+    "layer1.tint": "#878573",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#878573",
+    "layer2.tint": "#929181",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#878573",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#878573",
+    "layer0.tint": "#929181",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5f5e4e1e",
+    "layer0.tint": "#8785731e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#302f27",
+    "fg": "#5f5e4e",
     "match_fg": "#a5980d",
-    "selected_fg": "#6c6b5a",
+    "selected_fg": "#5f5e4e",
     "selected_match_fg": "#a5980d"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#302f27",
+    "fg": "#5f5e4e",
     "match_fg": "#a5980d",
-    "selected_fg": "#6c6b5a",
+    "selected_fg": "#5f5e4e",
     "selected_match_fg": "#a5980d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#302f27",
-    "match_fg": "#5f5e4e",
-    "selected_fg": "#6c6b5a",
-    "selected_match_fg": "#6c6b5a"
+    "fg": "#6c6b5a",
+    "match_fg": "#a5980d",
+    "selected_fg": "#5f5e4e",
+    "selected_match_fg": "#a5980d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#878573",
+    "layer0.tint": "#929181",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#302f27",
     "match_fg": "#a5980d",
-    "selected_fg": "transparent",
+    "selected_fg": "#22221b",
     "selected_match_fg": "#a5980d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f4f3ec",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#929181",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#929181",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#878573",
+    "layer0.tint": "#929181",
+    "color_scheme_tint": "#929181",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-estuary.sublime-theme
+++ b/base16-atelier-estuary.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#302f27",
+    "layer1.tint": "#6c6b5a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6c6b5a",
+    "layer2.tint": "#5f5e4e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6c6b5a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6c6b5a",
+    "layer0.tint": "#5f5e4e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#9291813f",
+    "layer0.tint": "#6c6b5a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e7e6df",
     "match_fg": "#a5980d",
-    "selected_fg": "#878573",
+    "selected_fg": "#f4f3ec",
     "selected_match_fg": "#a5980d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e7e6df",
     "match_fg": "#a5980d",
-    "selected_fg": "#878573",
+    "selected_fg": "#f4f3ec",
     "selected_match_fg": "#a5980d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e7e6df",
-    "match_fg": "#929181",
-    "selected_fg": "#878573",
-    "selected_match_fg": "#878573"
+    "fg": "#878573",
+    "match_fg": "#a5980d",
+    "selected_fg": "#929181",
+    "selected_match_fg": "#a5980d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6c6b5a",
+    "layer0.tint": "#5f5e4e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e7e6df",
     "match_fg": "#a5980d",
-    "selected_fg": "transparent",
+    "selected_fg": "#f4f3ec",
     "selected_match_fg": "#a5980d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#22221b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5f5e4e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5f5e4e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6c6b5a",
+    "layer0.tint": "#5f5e4e",
+    "color_scheme_tint": "#5f5e4e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-forest-light.sublime-theme
+++ b/base16-atelier-forest-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#a8a19f",
+    "layer0.tint": "#9c9491",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e6e2e01e",
+    "layer1.tint": "#9c9491",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9c9491",
+    "layer2.tint": "#a8a19f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9c9491",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9c9491",
+    "layer0.tint": "#a8a19f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#68615e1e",
+    "layer0.tint": "#9c94911e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#2c2421",
+    "fg": "#68615e",
     "match_fg": "#c38418",
-    "selected_fg": "#766e6b",
+    "selected_fg": "#68615e",
     "selected_match_fg": "#c38418"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#2c2421",
+    "fg": "#68615e",
     "match_fg": "#c38418",
-    "selected_fg": "#766e6b",
+    "selected_fg": "#68615e",
     "selected_match_fg": "#c38418"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#2c2421",
-    "match_fg": "#68615e",
-    "selected_fg": "#766e6b",
-    "selected_match_fg": "#766e6b"
+    "fg": "#766e6b",
+    "match_fg": "#c38418",
+    "selected_fg": "#68615e",
+    "selected_match_fg": "#c38418"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9c9491",
+    "layer0.tint": "#a8a19f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#2c2421",
     "match_fg": "#c38418",
-    "selected_fg": "transparent",
+    "selected_fg": "#1b1918",
     "selected_match_fg": "#c38418",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f1efee",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#a8a19f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#a8a19f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9c9491",
+    "layer0.tint": "#a8a19f",
+    "color_scheme_tint": "#a8a19f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-forest.sublime-theme
+++ b/base16-atelier-forest.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2c2421",
+    "layer1.tint": "#766e6b",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#766e6b",
+    "layer2.tint": "#68615e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#766e6b",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#766e6b",
+    "layer0.tint": "#68615e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a8a19f3f",
+    "layer0.tint": "#766e6b3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e6e2e0",
     "match_fg": "#c38418",
-    "selected_fg": "#9c9491",
+    "selected_fg": "#f1efee",
     "selected_match_fg": "#c38418"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e6e2e0",
     "match_fg": "#c38418",
-    "selected_fg": "#9c9491",
+    "selected_fg": "#f1efee",
     "selected_match_fg": "#c38418"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e6e2e0",
-    "match_fg": "#a8a19f",
-    "selected_fg": "#9c9491",
-    "selected_match_fg": "#9c9491"
+    "fg": "#9c9491",
+    "match_fg": "#c38418",
+    "selected_fg": "#a8a19f",
+    "selected_match_fg": "#c38418"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#766e6b",
+    "layer0.tint": "#68615e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e6e2e0",
     "match_fg": "#c38418",
-    "selected_fg": "transparent",
+    "selected_fg": "#f1efee",
     "selected_match_fg": "#c38418",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1b1918",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#68615e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#68615e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#766e6b",
+    "layer0.tint": "#68615e",
+    "color_scheme_tint": "#68615e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-heath-light.sublime-theme
+++ b/base16-atelier-heath-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#ab9bab",
+    "layer0.tint": "#9e8f9e",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#d8cad81e",
+    "layer1.tint": "#9e8f9e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9e8f9e",
+    "layer2.tint": "#ab9bab",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9e8f9e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9e8f9e",
+    "layer0.tint": "#ab9bab",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#695d691e",
+    "layer0.tint": "#9e8f9e1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#292329",
+    "fg": "#695d69",
     "match_fg": "#bb8a35",
-    "selected_fg": "#776977",
+    "selected_fg": "#695d69",
     "selected_match_fg": "#bb8a35"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#292329",
+    "fg": "#695d69",
     "match_fg": "#bb8a35",
-    "selected_fg": "#776977",
+    "selected_fg": "#695d69",
     "selected_match_fg": "#bb8a35"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#292329",
-    "match_fg": "#695d69",
-    "selected_fg": "#776977",
-    "selected_match_fg": "#776977"
+    "fg": "#776977",
+    "match_fg": "#bb8a35",
+    "selected_fg": "#695d69",
+    "selected_match_fg": "#bb8a35"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9e8f9e",
+    "layer0.tint": "#ab9bab",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#292329",
     "match_fg": "#bb8a35",
-    "selected_fg": "transparent",
+    "selected_fg": "#1b181b",
     "selected_match_fg": "#bb8a35",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f7f3f7",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#ab9bab",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#ab9bab",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9e8f9e",
+    "layer0.tint": "#ab9bab",
+    "color_scheme_tint": "#ab9bab",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-heath.sublime-theme
+++ b/base16-atelier-heath.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#292329",
+    "layer1.tint": "#776977",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#776977",
+    "layer2.tint": "#695d69",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#776977",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#776977",
+    "layer0.tint": "#695d69",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ab9bab3f",
+    "layer0.tint": "#7769773f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d8cad8",
     "match_fg": "#bb8a35",
-    "selected_fg": "#9e8f9e",
+    "selected_fg": "#f7f3f7",
     "selected_match_fg": "#bb8a35"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d8cad8",
     "match_fg": "#bb8a35",
-    "selected_fg": "#9e8f9e",
+    "selected_fg": "#f7f3f7",
     "selected_match_fg": "#bb8a35"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d8cad8",
-    "match_fg": "#ab9bab",
-    "selected_fg": "#9e8f9e",
-    "selected_match_fg": "#9e8f9e"
+    "fg": "#9e8f9e",
+    "match_fg": "#bb8a35",
+    "selected_fg": "#ab9bab",
+    "selected_match_fg": "#bb8a35"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#776977",
+    "layer0.tint": "#695d69",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d8cad8",
     "match_fg": "#bb8a35",
-    "selected_fg": "transparent",
+    "selected_fg": "#f7f3f7",
     "selected_match_fg": "#bb8a35",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1b181b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#695d69",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#695d69",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#776977",
+    "layer0.tint": "#695d69",
+    "color_scheme_tint": "#695d69",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-lakeside-light.sublime-theme
+++ b/base16-atelier-lakeside-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#7ea2b4",
+    "layer0.tint": "#7195a8",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#c1e4f61e",
+    "layer1.tint": "#7195a8",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7195a8",
+    "layer2.tint": "#7ea2b4",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7195a8",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7195a8",
+    "layer0.tint": "#7ea2b4",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#516d7b1e",
+    "layer0.tint": "#7195a81e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#1f292e",
+    "fg": "#516d7b",
     "match_fg": "#8a8a0f",
-    "selected_fg": "#5a7b8c",
+    "selected_fg": "#516d7b",
     "selected_match_fg": "#8a8a0f"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#1f292e",
+    "fg": "#516d7b",
     "match_fg": "#8a8a0f",
-    "selected_fg": "#5a7b8c",
+    "selected_fg": "#516d7b",
     "selected_match_fg": "#8a8a0f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#1f292e",
-    "match_fg": "#516d7b",
-    "selected_fg": "#5a7b8c",
-    "selected_match_fg": "#5a7b8c"
+    "fg": "#5a7b8c",
+    "match_fg": "#8a8a0f",
+    "selected_fg": "#516d7b",
+    "selected_match_fg": "#8a8a0f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7195a8",
+    "layer0.tint": "#7ea2b4",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#1f292e",
     "match_fg": "#8a8a0f",
-    "selected_fg": "transparent",
+    "selected_fg": "#161b1d",
     "selected_match_fg": "#8a8a0f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ebf8ff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#7ea2b4",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#7ea2b4",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7195a8",
+    "layer0.tint": "#7ea2b4",
+    "color_scheme_tint": "#7ea2b4",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-lakeside.sublime-theme
+++ b/base16-atelier-lakeside.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1f292e",
+    "layer1.tint": "#5a7b8c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5a7b8c",
+    "layer2.tint": "#516d7b",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5a7b8c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5a7b8c",
+    "layer0.tint": "#516d7b",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#7ea2b43f",
+    "layer0.tint": "#5a7b8c3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c1e4f6",
     "match_fg": "#8a8a0f",
-    "selected_fg": "#7195a8",
+    "selected_fg": "#ebf8ff",
     "selected_match_fg": "#8a8a0f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c1e4f6",
     "match_fg": "#8a8a0f",
-    "selected_fg": "#7195a8",
+    "selected_fg": "#ebf8ff",
     "selected_match_fg": "#8a8a0f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c1e4f6",
-    "match_fg": "#7ea2b4",
-    "selected_fg": "#7195a8",
-    "selected_match_fg": "#7195a8"
+    "fg": "#7195a8",
+    "match_fg": "#8a8a0f",
+    "selected_fg": "#7ea2b4",
+    "selected_match_fg": "#8a8a0f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5a7b8c",
+    "layer0.tint": "#516d7b",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c1e4f6",
     "match_fg": "#8a8a0f",
-    "selected_fg": "transparent",
+    "selected_fg": "#ebf8ff",
     "selected_match_fg": "#8a8a0f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#161b1d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#516d7b",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#516d7b",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5a7b8c",
+    "layer0.tint": "#516d7b",
+    "color_scheme_tint": "#516d7b",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-plateau-light.sublime-theme
+++ b/base16-atelier-plateau-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#8a8585",
+    "layer0.tint": "#7e7777",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e7dfdf1e",
+    "layer1.tint": "#7e7777",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7e7777",
+    "layer2.tint": "#8a8585",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7e7777",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7e7777",
+    "layer0.tint": "#8a8585",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5850501e",
+    "layer0.tint": "#7e77771e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#292424",
+    "fg": "#585050",
     "match_fg": "#a06e3b",
-    "selected_fg": "#655d5d",
+    "selected_fg": "#585050",
     "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#292424",
+    "fg": "#585050",
     "match_fg": "#a06e3b",
-    "selected_fg": "#655d5d",
+    "selected_fg": "#585050",
     "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#292424",
-    "match_fg": "#585050",
-    "selected_fg": "#655d5d",
-    "selected_match_fg": "#655d5d"
+    "fg": "#655d5d",
+    "match_fg": "#a06e3b",
+    "selected_fg": "#585050",
+    "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7e7777",
+    "layer0.tint": "#8a8585",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#292424",
     "match_fg": "#a06e3b",
-    "selected_fg": "transparent",
+    "selected_fg": "#1b1818",
     "selected_match_fg": "#a06e3b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f4ecec",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#8a8585",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#8a8585",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7e7777",
+    "layer0.tint": "#8a8585",
+    "color_scheme_tint": "#8a8585",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-plateau.sublime-theme
+++ b/base16-atelier-plateau.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#292424",
+    "layer1.tint": "#655d5d",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#655d5d",
+    "layer2.tint": "#585050",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#655d5d",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#655d5d",
+    "layer0.tint": "#585050",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8a85853f",
+    "layer0.tint": "#655d5d3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e7dfdf",
     "match_fg": "#a06e3b",
-    "selected_fg": "#7e7777",
+    "selected_fg": "#f4ecec",
     "selected_match_fg": "#a06e3b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e7dfdf",
     "match_fg": "#a06e3b",
-    "selected_fg": "#7e7777",
+    "selected_fg": "#f4ecec",
     "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e7dfdf",
-    "match_fg": "#8a8585",
-    "selected_fg": "#7e7777",
-    "selected_match_fg": "#7e7777"
+    "fg": "#7e7777",
+    "match_fg": "#a06e3b",
+    "selected_fg": "#8a8585",
+    "selected_match_fg": "#a06e3b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#655d5d",
+    "layer0.tint": "#585050",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e7dfdf",
     "match_fg": "#a06e3b",
-    "selected_fg": "transparent",
+    "selected_fg": "#f4ecec",
     "selected_match_fg": "#a06e3b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1b1818",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#585050",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#585050",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#655d5d",
+    "layer0.tint": "#585050",
+    "color_scheme_tint": "#585050",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-savanna-light.sublime-theme
+++ b/base16-atelier-savanna-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#87928a",
+    "layer0.tint": "#78877d",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#dfe7e21e",
+    "layer1.tint": "#78877d",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#78877d",
+    "layer2.tint": "#87928a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#78877d",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#78877d",
+    "layer0.tint": "#87928a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5260571e",
+    "layer0.tint": "#78877d1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#232a25",
+    "fg": "#526057",
     "match_fg": "#a07e3b",
-    "selected_fg": "#5f6d64",
+    "selected_fg": "#526057",
     "selected_match_fg": "#a07e3b"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#232a25",
+    "fg": "#526057",
     "match_fg": "#a07e3b",
-    "selected_fg": "#5f6d64",
+    "selected_fg": "#526057",
     "selected_match_fg": "#a07e3b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#232a25",
-    "match_fg": "#526057",
-    "selected_fg": "#5f6d64",
-    "selected_match_fg": "#5f6d64"
+    "fg": "#5f6d64",
+    "match_fg": "#a07e3b",
+    "selected_fg": "#526057",
+    "selected_match_fg": "#a07e3b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#78877d",
+    "layer0.tint": "#87928a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#232a25",
     "match_fg": "#a07e3b",
-    "selected_fg": "transparent",
+    "selected_fg": "#171c19",
     "selected_match_fg": "#a07e3b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ecf4ee",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#87928a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#87928a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#78877d",
+    "layer0.tint": "#87928a",
+    "color_scheme_tint": "#87928a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-savanna.sublime-theme
+++ b/base16-atelier-savanna.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#232a25",
+    "layer1.tint": "#5f6d64",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5f6d64",
+    "layer2.tint": "#526057",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5f6d64",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5f6d64",
+    "layer0.tint": "#526057",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#87928a3f",
+    "layer0.tint": "#5f6d643f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dfe7e2",
     "match_fg": "#a07e3b",
-    "selected_fg": "#78877d",
+    "selected_fg": "#ecf4ee",
     "selected_match_fg": "#a07e3b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dfe7e2",
     "match_fg": "#a07e3b",
-    "selected_fg": "#78877d",
+    "selected_fg": "#ecf4ee",
     "selected_match_fg": "#a07e3b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dfe7e2",
-    "match_fg": "#87928a",
-    "selected_fg": "#78877d",
-    "selected_match_fg": "#78877d"
+    "fg": "#78877d",
+    "match_fg": "#a07e3b",
+    "selected_fg": "#87928a",
+    "selected_match_fg": "#a07e3b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5f6d64",
+    "layer0.tint": "#526057",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dfe7e2",
     "match_fg": "#a07e3b",
-    "selected_fg": "transparent",
+    "selected_fg": "#ecf4ee",
     "selected_match_fg": "#a07e3b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#171c19",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#526057",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#526057",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5f6d64",
+    "layer0.tint": "#526057",
+    "color_scheme_tint": "#526057",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-seaside-light.sublime-theme
+++ b/base16-atelier-seaside-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#8ca68c",
+    "layer0.tint": "#809980",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#cfe8cf1e",
+    "layer1.tint": "#809980",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#809980",
+    "layer2.tint": "#8ca68c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#809980",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#809980",
+    "layer0.tint": "#8ca68c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5e6e5e1e",
+    "layer0.tint": "#8099801e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#242924",
+    "fg": "#5e6e5e",
     "match_fg": "#98981b",
-    "selected_fg": "#687d68",
+    "selected_fg": "#5e6e5e",
     "selected_match_fg": "#98981b"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#242924",
+    "fg": "#5e6e5e",
     "match_fg": "#98981b",
-    "selected_fg": "#687d68",
+    "selected_fg": "#5e6e5e",
     "selected_match_fg": "#98981b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#242924",
-    "match_fg": "#5e6e5e",
-    "selected_fg": "#687d68",
-    "selected_match_fg": "#687d68"
+    "fg": "#687d68",
+    "match_fg": "#98981b",
+    "selected_fg": "#5e6e5e",
+    "selected_match_fg": "#98981b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#809980",
+    "layer0.tint": "#8ca68c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#242924",
     "match_fg": "#98981b",
-    "selected_fg": "transparent",
+    "selected_fg": "#131513",
     "selected_match_fg": "#98981b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f4fbf4",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#8ca68c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#8ca68c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#809980",
+    "layer0.tint": "#8ca68c",
+    "color_scheme_tint": "#8ca68c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-seaside.sublime-theme
+++ b/base16-atelier-seaside.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#242924",
+    "layer1.tint": "#687d68",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#687d68",
+    "layer2.tint": "#5e6e5e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#687d68",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#687d68",
+    "layer0.tint": "#5e6e5e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8ca68c3f",
+    "layer0.tint": "#687d683f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cfe8cf",
     "match_fg": "#98981b",
-    "selected_fg": "#809980",
+    "selected_fg": "#f4fbf4",
     "selected_match_fg": "#98981b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cfe8cf",
     "match_fg": "#98981b",
-    "selected_fg": "#809980",
+    "selected_fg": "#f4fbf4",
     "selected_match_fg": "#98981b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cfe8cf",
-    "match_fg": "#8ca68c",
-    "selected_fg": "#809980",
-    "selected_match_fg": "#809980"
+    "fg": "#809980",
+    "match_fg": "#98981b",
+    "selected_fg": "#8ca68c",
+    "selected_match_fg": "#98981b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#687d68",
+    "layer0.tint": "#5e6e5e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cfe8cf",
     "match_fg": "#98981b",
-    "selected_fg": "transparent",
+    "selected_fg": "#f4fbf4",
     "selected_match_fg": "#98981b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#131513",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5e6e5e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5e6e5e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#687d68",
+    "layer0.tint": "#5e6e5e",
+    "color_scheme_tint": "#5e6e5e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-sulphurpool-light.sublime-theme
+++ b/base16-atelier-sulphurpool-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#979db4",
+    "layer0.tint": "#898ea4",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#dfe2f11e",
+    "layer1.tint": "#898ea4",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#898ea4",
+    "layer2.tint": "#979db4",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#898ea4",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#898ea4",
+    "layer0.tint": "#979db4",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5e66871e",
+    "layer0.tint": "#898ea41e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#293256",
+    "fg": "#5e6687",
     "match_fg": "#c08b30",
-    "selected_fg": "#6b7394",
+    "selected_fg": "#5e6687",
     "selected_match_fg": "#c08b30"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#293256",
+    "fg": "#5e6687",
     "match_fg": "#c08b30",
-    "selected_fg": "#6b7394",
+    "selected_fg": "#5e6687",
     "selected_match_fg": "#c08b30"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#293256",
-    "match_fg": "#5e6687",
-    "selected_fg": "#6b7394",
-    "selected_match_fg": "#6b7394"
+    "fg": "#6b7394",
+    "match_fg": "#c08b30",
+    "selected_fg": "#5e6687",
+    "selected_match_fg": "#c08b30"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#898ea4",
+    "layer0.tint": "#979db4",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#293256",
     "match_fg": "#c08b30",
-    "selected_fg": "transparent",
+    "selected_fg": "#202746",
     "selected_match_fg": "#c08b30",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f5f7ff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#979db4",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#979db4",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#898ea4",
+    "layer0.tint": "#979db4",
+    "color_scheme_tint": "#979db4",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atelier-sulphurpool.sublime-theme
+++ b/base16-atelier-sulphurpool.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#293256",
+    "layer1.tint": "#6b7394",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6b7394",
+    "layer2.tint": "#5e6687",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6b7394",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6b7394",
+    "layer0.tint": "#5e6687",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#979db43f",
+    "layer0.tint": "#6b73943f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dfe2f1",
     "match_fg": "#c08b30",
-    "selected_fg": "#898ea4",
+    "selected_fg": "#f5f7ff",
     "selected_match_fg": "#c08b30"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dfe2f1",
     "match_fg": "#c08b30",
-    "selected_fg": "#898ea4",
+    "selected_fg": "#f5f7ff",
     "selected_match_fg": "#c08b30"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dfe2f1",
-    "match_fg": "#979db4",
-    "selected_fg": "#898ea4",
-    "selected_match_fg": "#898ea4"
+    "fg": "#898ea4",
+    "match_fg": "#c08b30",
+    "selected_fg": "#979db4",
+    "selected_match_fg": "#c08b30"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6b7394",
+    "layer0.tint": "#5e6687",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dfe2f1",
     "match_fg": "#c08b30",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5f7ff",
     "selected_match_fg": "#c08b30",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#202746",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5e6687",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5e6687",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6b7394",
+    "layer0.tint": "#5e6687",
+    "color_scheme_tint": "#5e6687",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-atlas.sublime-theme
+++ b/base16-atlas.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#00384d",
+    "layer1.tint": "#6c8b91",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6c8b91",
+    "layer2.tint": "#517f8d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6c8b91",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6c8b91",
+    "layer0.tint": "#517f8d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a1a19a3f",
+    "layer0.tint": "#6c8b913f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e6e6dc",
     "match_fg": "#ffcc1b",
-    "selected_fg": "#869696",
+    "selected_fg": "#fafaf8",
     "selected_match_fg": "#ffcc1b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e6e6dc",
     "match_fg": "#ffcc1b",
-    "selected_fg": "#869696",
+    "selected_fg": "#fafaf8",
     "selected_match_fg": "#ffcc1b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e6e6dc",
-    "match_fg": "#a1a19a",
-    "selected_fg": "#869696",
-    "selected_match_fg": "#869696"
+    "fg": "#869696",
+    "match_fg": "#ffcc1b",
+    "selected_fg": "#a1a19a",
+    "selected_match_fg": "#ffcc1b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6c8b91",
+    "layer0.tint": "#517f8d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e6e6dc",
     "match_fg": "#ffcc1b",
-    "selected_fg": "transparent",
+    "selected_fg": "#fafaf8",
     "selected_match_fg": "#ffcc1b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#002635",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#517f8d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#517f8d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6c8b91",
+    "layer0.tint": "#517f8d",
+    "color_scheme_tint": "#517f8d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-ayu-dark.sublime-theme
+++ b/base16-ayu-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#131721",
+    "layer1.tint": "#3e4b59",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#3e4b59",
+    "layer2.tint": "#272d38",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#3e4b59",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#3e4b59",
+    "layer0.tint": "#272d38",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e6e1cf3f",
+    "layer0.tint": "#3e4b593f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e6e1cf",
     "match_fg": "#ffb454",
-    "selected_fg": "#bfbdb6",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#ffb454"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e6e1cf",
     "match_fg": "#ffb454",
-    "selected_fg": "#bfbdb6",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#ffb454"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e6e1cf",
-    "match_fg": "#e6e1cf",
-    "selected_fg": "#bfbdb6",
-    "selected_match_fg": "#bfbdb6"
+    "fg": "#bfbdb6",
+    "match_fg": "#ffb454",
+    "selected_fg": "#e6e1cf",
+    "selected_match_fg": "#ffb454"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#3e4b59",
+    "layer0.tint": "#272d38",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e6e1cf",
     "match_fg": "#ffb454",
-    "selected_fg": "transparent",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#ffb454",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0f1419",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#272d38",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#272d38",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#3e4b59",
+    "layer0.tint": "#272d38",
+    "color_scheme_tint": "#272d38",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-ayu-light.sublime-theme
+++ b/base16-ayu-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#f8f9fa",
+    "layer0.tint": "#abb0b6",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f3f4f51e",
+    "layer1.tint": "#abb0b6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#abb0b6",
+    "layer2.tint": "#f8f9fa",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#abb0b6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#abb0b6",
+    "layer0.tint": "#f8f9fa",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5c67731e",
+    "layer0.tint": "#abb0b61e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#242936",
+    "fg": "#5c6773",
     "match_fg": "#f2ae49",
-    "selected_fg": "#828c99",
+    "selected_fg": "#5c6773",
     "selected_match_fg": "#f2ae49"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#242936",
+    "fg": "#5c6773",
     "match_fg": "#f2ae49",
-    "selected_fg": "#828c99",
+    "selected_fg": "#5c6773",
     "selected_match_fg": "#f2ae49"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#242936",
-    "match_fg": "#5c6773",
-    "selected_fg": "#828c99",
-    "selected_match_fg": "#828c99"
+    "fg": "#828c99",
+    "match_fg": "#f2ae49",
+    "selected_fg": "#5c6773",
+    "selected_match_fg": "#f2ae49"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#abb0b6",
+    "layer0.tint": "#f8f9fa",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#242936",
     "match_fg": "#f2ae49",
-    "selected_fg": "transparent",
+    "selected_fg": "#1a1f29",
     "selected_match_fg": "#f2ae49",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fafafa",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#f8f9fa",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#f8f9fa",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#abb0b6",
+    "layer0.tint": "#f8f9fa",
+    "color_scheme_tint": "#f8f9fa",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-ayu-mirage.sublime-theme
+++ b/base16-ayu-mirage.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1f2430",
+    "layer1.tint": "#707a8c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#707a8c",
+    "layer2.tint": "#242936",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#707a8c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#707a8c",
+    "layer0.tint": "#242936",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cccac23f",
+    "layer0.tint": "#707a8c3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d9d7ce",
     "match_fg": "#ffd173",
-    "selected_fg": "#8a9199",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#ffd173"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d9d7ce",
     "match_fg": "#ffd173",
-    "selected_fg": "#8a9199",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#ffd173"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d9d7ce",
-    "match_fg": "#cccac2",
-    "selected_fg": "#8a9199",
-    "selected_match_fg": "#8a9199"
+    "fg": "#8a9199",
+    "match_fg": "#ffd173",
+    "selected_fg": "#cccac2",
+    "selected_match_fg": "#ffd173"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#707a8c",
+    "layer0.tint": "#242936",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d9d7ce",
     "match_fg": "#ffd173",
-    "selected_fg": "transparent",
+    "selected_fg": "#f3f4f5",
     "selected_match_fg": "#ffd173",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#171b24",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#242936",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#242936",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#707a8c",
+    "layer0.tint": "#242936",
+    "color_scheme_tint": "#242936",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-aztec.sublime-theme
+++ b/base16-aztec.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1a1e01",
+    "layer1.tint": "#2e2e05",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#2e2e05",
+    "layer2.tint": "#242604",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#2e2e05",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#2e2e05",
+    "layer0.tint": "#242604",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ffda513f",
+    "layer0.tint": "#2e2e053f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffe178",
     "match_fg": "#eebb00",
-    "selected_fg": "#ffd129",
+    "selected_fg": "#ffeba0",
     "selected_match_fg": "#eebb00"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffe178",
     "match_fg": "#eebb00",
-    "selected_fg": "#ffd129",
+    "selected_fg": "#ffeba0",
     "selected_match_fg": "#eebb00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffe178",
-    "match_fg": "#ffda51",
-    "selected_fg": "#ffd129",
-    "selected_match_fg": "#ffd129"
+    "fg": "#ffd129",
+    "match_fg": "#eebb00",
+    "selected_fg": "#ffda51",
+    "selected_match_fg": "#eebb00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#2e2e05",
+    "layer0.tint": "#242604",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffe178",
     "match_fg": "#eebb00",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffeba0",
     "selected_match_fg": "#eebb00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#101600",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#242604",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#242604",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#2e2e05",
+    "layer0.tint": "#242604",
+    "color_scheme_tint": "#242604",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-bespin.sublime-theme
+++ b/base16-bespin.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#36312e",
+    "layer1.tint": "#666666",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#666666",
+    "layer2.tint": "#5e5d5c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#666666",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#666666",
+    "layer0.tint": "#5e5d5c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8a89863f",
+    "layer0.tint": "#6666663f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#9d9b97",
     "match_fg": "#f9ee98",
-    "selected_fg": "#797977",
+    "selected_fg": "#baae9e",
     "selected_match_fg": "#f9ee98"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#9d9b97",
     "match_fg": "#f9ee98",
-    "selected_fg": "#797977",
+    "selected_fg": "#baae9e",
     "selected_match_fg": "#f9ee98"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#9d9b97",
-    "match_fg": "#8a8986",
-    "selected_fg": "#797977",
-    "selected_match_fg": "#797977"
+    "fg": "#797977",
+    "match_fg": "#f9ee98",
+    "selected_fg": "#8a8986",
+    "selected_match_fg": "#f9ee98"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#666666",
+    "layer0.tint": "#5e5d5c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#9d9b97",
     "match_fg": "#f9ee98",
-    "selected_fg": "transparent",
+    "selected_fg": "#baae9e",
     "selected_match_fg": "#f9ee98",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#28211c",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5e5d5c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5e5d5c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#666666",
+    "layer0.tint": "#5e5d5c",
+    "color_scheme_tint": "#5e5d5c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-bathory.sublime-theme
+++ b/base16-black-metal-bathory.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#e78a53",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#e78a53"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#e78a53",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#e78a53"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#e78a53",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#e78a53"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#e78a53",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#e78a53",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-burzum.sublime-theme
+++ b/base16-black-metal-burzum.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#99bbaa",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#99bbaa"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#99bbaa",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#99bbaa"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#99bbaa",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#99bbaa"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#99bbaa",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#99bbaa",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-dark-funeral.sublime-theme
+++ b/base16-black-metal-dark-funeral.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#5f81a5",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#5f81a5"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#5f81a5",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#5f81a5"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#5f81a5",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#5f81a5"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#5f81a5",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#5f81a5",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-gorgoroth.sublime-theme
+++ b/base16-black-metal-gorgoroth.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#8c7f70",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#8c7f70"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#8c7f70",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#8c7f70"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#8c7f70",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#8c7f70"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#8c7f70",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#8c7f70",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-immortal.sublime-theme
+++ b/base16-black-metal-immortal.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#556677",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#556677"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#556677",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#556677"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#556677",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#556677"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#556677",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#556677",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-khold.sublime-theme
+++ b/base16-black-metal-khold.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#974b46",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#974b46"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#974b46",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#974b46"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#974b46",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#974b46"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#974b46",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#974b46",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-marduk.sublime-theme
+++ b/base16-black-metal-marduk.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#626b67",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#626b67"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#626b67",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#626b67"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#626b67",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#626b67"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#626b67",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#626b67",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-mayhem.sublime-theme
+++ b/base16-black-metal-mayhem.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#eecc6c",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#eecc6c"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#eecc6c",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#eecc6c"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#eecc6c",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#eecc6c"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#eecc6c",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#eecc6c",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-nile.sublime-theme
+++ b/base16-black-metal-nile.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#777755",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#777755"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#777755",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#777755"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#777755",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#777755"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#777755",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#777755",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal-venom.sublime-theme
+++ b/base16-black-metal-venom.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#79241f",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#79241f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#79241f",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#79241f"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#79241f",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#79241f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#79241f",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#79241f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-black-metal.sublime-theme
+++ b/base16-black-metal.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#121212",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c1c13f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#999999",
     "match_fg": "#a06666",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#a06666"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#999999",
     "match_fg": "#a06666",
-    "selected_fg": "#999999",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#a06666"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#999999",
-    "match_fg": "#c1c1c1",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "match_fg": "#a06666",
+    "selected_fg": "#c1c1c1",
+    "selected_match_fg": "#a06666"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#999999",
     "match_fg": "#a06666",
-    "selected_fg": "transparent",
+    "selected_fg": "#c1c1c1",
     "selected_match_fg": "#a06666",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-blueforest.sublime-theme
+++ b/base16-blueforest.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1e5c1e",
+    "layer1.tint": "#a0ffa0",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#a0ffa0",
+    "layer2.tint": "#273e5c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#a0ffa0",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#a0ffa0",
+    "layer0.tint": "#273e5c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ffcc333f",
+    "layer0.tint": "#a0ffa03f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#91ccff",
     "match_fg": "#91ccff",
-    "selected_fg": "#1e5c1e",
+    "selected_fg": "#375780",
     "selected_match_fg": "#91ccff"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#91ccff",
     "match_fg": "#91ccff",
-    "selected_fg": "#1e5c1e",
+    "selected_fg": "#375780",
     "selected_match_fg": "#91ccff"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#91ccff",
-    "match_fg": "#ffcc33",
-    "selected_fg": "#1e5c1e",
-    "selected_match_fg": "#1e5c1e"
+    "fg": "#1e5c1e",
+    "match_fg": "#91ccff",
+    "selected_fg": "#ffcc33",
+    "selected_match_fg": "#91ccff"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#a0ffa0",
+    "layer0.tint": "#273e5c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#91ccff",
     "match_fg": "#91ccff",
-    "selected_fg": "transparent",
+    "selected_fg": "#375780",
     "selected_match_fg": "#91ccff",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#141f2e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#273e5c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#273e5c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#a0ffa0",
+    "layer0.tint": "#273e5c",
+    "color_scheme_tint": "#273e5c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-blueish.sublime-theme
+++ b/base16-blueish.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#243c54",
+    "layer1.tint": "#616d78",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#616d78",
+    "layer2.tint": "#46290a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#616d78",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#616d78",
+    "layer0.tint": "#46290a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c8e1f83f",
+    "layer0.tint": "#616d783f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ddeaf6",
     "match_fg": "#82aaff",
-    "selected_fg": "#74afe7",
+    "selected_fg": "#8f98a0",
     "selected_match_fg": "#82aaff"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ddeaf6",
     "match_fg": "#82aaff",
-    "selected_fg": "#74afe7",
+    "selected_fg": "#8f98a0",
     "selected_match_fg": "#82aaff"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ddeaf6",
-    "match_fg": "#c8e1f8",
-    "selected_fg": "#74afe7",
-    "selected_match_fg": "#74afe7"
+    "fg": "#74afe7",
+    "match_fg": "#82aaff",
+    "selected_fg": "#c8e1f8",
+    "selected_match_fg": "#82aaff"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#616d78",
+    "layer0.tint": "#46290a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ddeaf6",
     "match_fg": "#82aaff",
-    "selected_fg": "transparent",
+    "selected_fg": "#8f98a0",
     "selected_match_fg": "#82aaff",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#182430",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#46290a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#46290a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#616d78",
+    "layer0.tint": "#46290a",
+    "color_scheme_tint": "#46290a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-brewer.sublime-theme
+++ b/base16-brewer.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2e2f30",
+    "layer1.tint": "#737475",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#737475",
+    "layer2.tint": "#515253",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#737475",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#737475",
+    "layer0.tint": "#515253",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b7b8b93f",
+    "layer0.tint": "#7374753f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dadbdc",
     "match_fg": "#dca060",
-    "selected_fg": "#959697",
+    "selected_fg": "#fcfdfe",
     "selected_match_fg": "#dca060"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dadbdc",
     "match_fg": "#dca060",
-    "selected_fg": "#959697",
+    "selected_fg": "#fcfdfe",
     "selected_match_fg": "#dca060"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dadbdc",
-    "match_fg": "#b7b8b9",
-    "selected_fg": "#959697",
-    "selected_match_fg": "#959697"
+    "fg": "#959697",
+    "match_fg": "#dca060",
+    "selected_fg": "#b7b8b9",
+    "selected_match_fg": "#dca060"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#737475",
+    "layer0.tint": "#515253",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dadbdc",
     "match_fg": "#dca060",
-    "selected_fg": "transparent",
+    "selected_fg": "#fcfdfe",
     "selected_match_fg": "#dca060",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0c0d0e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#515253",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#515253",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#737475",
+    "layer0.tint": "#515253",
+    "color_scheme_tint": "#515253",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-bright.sublime-theme
+++ b/base16-bright.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#303030",
+    "layer1.tint": "#b0b0b0",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b0b0b0",
+    "layer2.tint": "#505050",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b0b0b0",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#505050",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e0e0e03f",
+    "layer0.tint": "#b0b0b03f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f5f5f5",
     "match_fg": "#fda331",
-    "selected_fg": "#d0d0d0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fda331"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f5f5f5",
     "match_fg": "#fda331",
-    "selected_fg": "#d0d0d0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fda331"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f5f5f5",
-    "match_fg": "#e0e0e0",
-    "selected_fg": "#d0d0d0",
-    "selected_match_fg": "#d0d0d0"
+    "fg": "#d0d0d0",
+    "match_fg": "#fda331",
+    "selected_fg": "#e0e0e0",
+    "selected_match_fg": "#fda331"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#505050",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f5f5f5",
     "match_fg": "#fda331",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fda331",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#505050",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#505050",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#505050",
+    "color_scheme_tint": "#505050",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-brogrammer.sublime-theme
+++ b/base16-brogrammer.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f81118",
+    "layer1.tint": "#ecba0f",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#ecba0f",
+    "layer2.tint": "#2dc55e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#ecba0f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#ecba0f",
+    "layer0.tint": "#2dc55e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4e5ab73f",
+    "layer0.tint": "#ecba0f3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#1081d6",
     "match_fg": "#1dd361",
-    "selected_fg": "#2a84d2",
+    "selected_fg": "#d6dbe5",
     "selected_match_fg": "#1dd361"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#1081d6",
     "match_fg": "#1dd361",
-    "selected_fg": "#2a84d2",
+    "selected_fg": "#d6dbe5",
     "selected_match_fg": "#1dd361"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#1081d6",
-    "match_fg": "#4e5ab7",
-    "selected_fg": "#2a84d2",
-    "selected_match_fg": "#2a84d2"
+    "fg": "#2a84d2",
+    "match_fg": "#1dd361",
+    "selected_fg": "#4e5ab7",
+    "selected_match_fg": "#1dd361"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#ecba0f",
+    "layer0.tint": "#2dc55e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#1081d6",
     "match_fg": "#1dd361",
-    "selected_fg": "transparent",
+    "selected_fg": "#d6dbe5",
     "selected_match_fg": "#1dd361",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1f1f1f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2dc55e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2dc55e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#ecba0f",
+    "layer0.tint": "#2dc55e",
+    "color_scheme_tint": "#2dc55e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-brushtrees-dark.sublime-theme
+++ b/base16-brushtrees-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#5a6d7a",
+    "layer1.tint": "#8299a1",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#8299a1",
+    "layer2.tint": "#6d828e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#8299a1",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#8299a1",
+    "layer0.tint": "#6d828e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b0c5c83f",
+    "layer0.tint": "#8299a13f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c9dbdc",
     "match_fg": "#aab386",
-    "selected_fg": "#98afb5",
+    "selected_fg": "#e3efef",
     "selected_match_fg": "#aab386"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c9dbdc",
     "match_fg": "#aab386",
-    "selected_fg": "#98afb5",
+    "selected_fg": "#e3efef",
     "selected_match_fg": "#aab386"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c9dbdc",
-    "match_fg": "#b0c5c8",
-    "selected_fg": "#98afb5",
-    "selected_match_fg": "#98afb5"
+    "fg": "#98afb5",
+    "match_fg": "#aab386",
+    "selected_fg": "#b0c5c8",
+    "selected_match_fg": "#aab386"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#8299a1",
+    "layer0.tint": "#6d828e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c9dbdc",
     "match_fg": "#aab386",
-    "selected_fg": "transparent",
+    "selected_fg": "#e3efef",
     "selected_match_fg": "#aab386",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#485867",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#6d828e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#6d828e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#8299a1",
+    "layer0.tint": "#6d828e",
+    "color_scheme_tint": "#6d828e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-brushtrees.sublime-theme
+++ b/base16-brushtrees.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#c9dbdc",
+    "layer1.tint": "#98afb5",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#98afb5",
+    "layer2.tint": "#b0c5c8",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#98afb5",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#98afb5",
+    "layer0.tint": "#b0c5c8",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#6d828e3f",
+    "layer0.tint": "#98afb53f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#5a6d7a",
     "match_fg": "#aab386",
-    "selected_fg": "#8299a1",
+    "selected_fg": "#485867",
     "selected_match_fg": "#aab386"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#5a6d7a",
     "match_fg": "#aab386",
-    "selected_fg": "#8299a1",
+    "selected_fg": "#485867",
     "selected_match_fg": "#aab386"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#5a6d7a",
-    "match_fg": "#6d828e",
-    "selected_fg": "#8299a1",
-    "selected_match_fg": "#8299a1"
+    "fg": "#8299a1",
+    "match_fg": "#aab386",
+    "selected_fg": "#6d828e",
+    "selected_match_fg": "#aab386"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#98afb5",
+    "layer0.tint": "#b0c5c8",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#5a6d7a",
     "match_fg": "#aab386",
-    "selected_fg": "transparent",
+    "selected_fg": "#485867",
     "selected_match_fg": "#aab386",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#e3efef",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#b0c5c8",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#b0c5c8",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#98afb5",
+    "layer0.tint": "#b0c5c8",
+    "color_scheme_tint": "#b0c5c8",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-caroline.sublime-theme
+++ b/base16-caroline.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3a2425",
+    "layer1.tint": "#6d4745",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6d4745",
+    "layer2.tint": "#563837",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6d4745",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6d4745",
+    "layer0.tint": "#563837",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a875693f",
+    "layer0.tint": "#6d47453f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c58d7b",
     "match_fg": "#f28171",
-    "selected_fg": "#8b5d57",
+    "selected_fg": "#e3a68c",
     "selected_match_fg": "#f28171"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c58d7b",
     "match_fg": "#f28171",
-    "selected_fg": "#8b5d57",
+    "selected_fg": "#e3a68c",
     "selected_match_fg": "#f28171"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c58d7b",
-    "match_fg": "#a87569",
-    "selected_fg": "#8b5d57",
-    "selected_match_fg": "#8b5d57"
+    "fg": "#8b5d57",
+    "match_fg": "#f28171",
+    "selected_fg": "#a87569",
+    "selected_match_fg": "#f28171"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6d4745",
+    "layer0.tint": "#563837",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c58d7b",
     "match_fg": "#f28171",
-    "selected_fg": "transparent",
+    "selected_fg": "#e3a68c",
     "selected_match_fg": "#f28171",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1c1213",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#563837",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#563837",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6d4745",
+    "layer0.tint": "#563837",
+    "color_scheme_tint": "#563837",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-catppuccin-frappe.sublime-theme
+++ b/base16-catppuccin-frappe.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#292c3c",
+    "layer1.tint": "#51576d",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#51576d",
+    "layer2.tint": "#414559",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#51576d",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#51576d",
+    "layer0.tint": "#414559",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c6d0f53f",
+    "layer0.tint": "#51576d3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f2d5cf",
     "match_fg": "#e5c890",
-    "selected_fg": "#626880",
+    "selected_fg": "#babbf1",
     "selected_match_fg": "#e5c890"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f2d5cf",
     "match_fg": "#e5c890",
-    "selected_fg": "#626880",
+    "selected_fg": "#babbf1",
     "selected_match_fg": "#e5c890"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f2d5cf",
-    "match_fg": "#c6d0f5",
-    "selected_fg": "#626880",
-    "selected_match_fg": "#626880"
+    "fg": "#626880",
+    "match_fg": "#e5c890",
+    "selected_fg": "#c6d0f5",
+    "selected_match_fg": "#e5c890"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#51576d",
+    "layer0.tint": "#414559",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f2d5cf",
     "match_fg": "#e5c890",
-    "selected_fg": "transparent",
+    "selected_fg": "#babbf1",
     "selected_match_fg": "#e5c890",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#303446",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#414559",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#414559",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#51576d",
+    "layer0.tint": "#414559",
+    "color_scheme_tint": "#414559",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-catppuccin-latte.sublime-theme
+++ b/base16-catppuccin-latte.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#ccd0da",
+    "layer0.tint": "#bcc0cc",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e6e9ef1e",
+    "layer1.tint": "#bcc0cc",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#bcc0cc",
+    "layer2.tint": "#ccd0da",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#bcc0cc",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#bcc0cc",
+    "layer0.tint": "#ccd0da",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4c4f691e",
+    "layer0.tint": "#bcc0cc1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#dc8a78",
+    "fg": "#4c4f69",
     "match_fg": "#df8e1d",
-    "selected_fg": "#acb0be",
+    "selected_fg": "#4c4f69",
     "selected_match_fg": "#df8e1d"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#dc8a78",
+    "fg": "#4c4f69",
     "match_fg": "#df8e1d",
-    "selected_fg": "#acb0be",
+    "selected_fg": "#4c4f69",
     "selected_match_fg": "#df8e1d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dc8a78",
-    "match_fg": "#4c4f69",
-    "selected_fg": "#acb0be",
-    "selected_match_fg": "#acb0be"
+    "fg": "#acb0be",
+    "match_fg": "#df8e1d",
+    "selected_fg": "#4c4f69",
+    "selected_match_fg": "#df8e1d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#bcc0cc",
+    "layer0.tint": "#ccd0da",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dc8a78",
     "match_fg": "#df8e1d",
-    "selected_fg": "transparent",
+    "selected_fg": "#7287fd",
     "selected_match_fg": "#df8e1d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#eff1f5",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#ccd0da",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#ccd0da",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#bcc0cc",
+    "layer0.tint": "#ccd0da",
+    "color_scheme_tint": "#ccd0da",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-catppuccin-macchiato.sublime-theme
+++ b/base16-catppuccin-macchiato.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1e2030",
+    "layer1.tint": "#494d64",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#494d64",
+    "layer2.tint": "#363a4f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#494d64",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#494d64",
+    "layer0.tint": "#363a4f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cad3f53f",
+    "layer0.tint": "#494d643f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f4dbd6",
     "match_fg": "#eed49f",
-    "selected_fg": "#5b6078",
+    "selected_fg": "#b7bdf8",
     "selected_match_fg": "#eed49f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f4dbd6",
     "match_fg": "#eed49f",
-    "selected_fg": "#5b6078",
+    "selected_fg": "#b7bdf8",
     "selected_match_fg": "#eed49f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f4dbd6",
-    "match_fg": "#cad3f5",
-    "selected_fg": "#5b6078",
-    "selected_match_fg": "#5b6078"
+    "fg": "#5b6078",
+    "match_fg": "#eed49f",
+    "selected_fg": "#cad3f5",
+    "selected_match_fg": "#eed49f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#494d64",
+    "layer0.tint": "#363a4f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f4dbd6",
     "match_fg": "#eed49f",
-    "selected_fg": "transparent",
+    "selected_fg": "#b7bdf8",
     "selected_match_fg": "#eed49f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#24273a",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#363a4f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#363a4f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#494d64",
+    "layer0.tint": "#363a4f",
+    "color_scheme_tint": "#363a4f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-catppuccin-mocha.sublime-theme
+++ b/base16-catppuccin-mocha.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#181825",
+    "layer1.tint": "#45475a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#45475a",
+    "layer2.tint": "#313244",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#45475a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#45475a",
+    "layer0.tint": "#313244",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cdd6f43f",
+    "layer0.tint": "#45475a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f5e0dc",
     "match_fg": "#f9e2af",
-    "selected_fg": "#585b70",
+    "selected_fg": "#b4befe",
     "selected_match_fg": "#f9e2af"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f5e0dc",
     "match_fg": "#f9e2af",
-    "selected_fg": "#585b70",
+    "selected_fg": "#b4befe",
     "selected_match_fg": "#f9e2af"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f5e0dc",
-    "match_fg": "#cdd6f4",
-    "selected_fg": "#585b70",
-    "selected_match_fg": "#585b70"
+    "fg": "#585b70",
+    "match_fg": "#f9e2af",
+    "selected_fg": "#cdd6f4",
+    "selected_match_fg": "#f9e2af"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#45475a",
+    "layer0.tint": "#313244",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f5e0dc",
     "match_fg": "#f9e2af",
-    "selected_fg": "transparent",
+    "selected_fg": "#b4befe",
     "selected_match_fg": "#f9e2af",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1e1e2e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#313244",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#313244",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#45475a",
+    "layer0.tint": "#313244",
+    "color_scheme_tint": "#313244",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-chalk.sublime-theme
+++ b/base16-chalk.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#202020",
+    "layer1.tint": "#505050",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#505050",
+    "layer2.tint": "#303030",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#505050",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0d0d03f",
+    "layer0.tint": "#5050503f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#ddb26f",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#ddb26f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#ddb26f",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#ddb26f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#d0d0d0",
-    "selected_fg": "#b0b0b0",
-    "selected_match_fg": "#b0b0b0"
+    "fg": "#b0b0b0",
+    "match_fg": "#ddb26f",
+    "selected_fg": "#d0d0d0",
+    "selected_match_fg": "#ddb26f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#ddb26f",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#ddb26f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#151515",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
+    "color_scheme_tint": "#303030",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-circus.sublime-theme
+++ b/base16-circus.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#202020",
+    "layer1.tint": "#5f5a60",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5f5a60",
+    "layer2.tint": "#303030",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5f5a60",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5f5a60",
+    "layer0.tint": "#303030",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a7a7a73f",
+    "layer0.tint": "#5f5a603f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#808080",
     "match_fg": "#c3ba63",
-    "selected_fg": "#505050",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#c3ba63"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#808080",
     "match_fg": "#c3ba63",
-    "selected_fg": "#505050",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#c3ba63"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#808080",
-    "match_fg": "#a7a7a7",
-    "selected_fg": "#505050",
-    "selected_match_fg": "#505050"
+    "fg": "#505050",
+    "match_fg": "#c3ba63",
+    "selected_fg": "#a7a7a7",
+    "selected_match_fg": "#c3ba63"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5f5a60",
+    "layer0.tint": "#303030",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#808080",
     "match_fg": "#c3ba63",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#c3ba63",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#191919",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5f5a60",
+    "layer0.tint": "#303030",
+    "color_scheme_tint": "#303030",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-classic-dark.sublime-theme
+++ b/base16-classic-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#202020",
+    "layer1.tint": "#505050",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#505050",
+    "layer2.tint": "#303030",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#505050",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0d0d03f",
+    "layer0.tint": "#5050503f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#f4bf75",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#f4bf75"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#f4bf75",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#f4bf75"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#d0d0d0",
-    "selected_fg": "#b0b0b0",
-    "selected_match_fg": "#b0b0b0"
+    "fg": "#b0b0b0",
+    "match_fg": "#f4bf75",
+    "selected_fg": "#d0d0d0",
+    "selected_match_fg": "#f4bf75"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#f4bf75",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#f4bf75",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#151515",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
+    "color_scheme_tint": "#303030",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-classic-light.sublime-theme
+++ b/base16-classic-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d0d0d0",
+    "layer0.tint": "#b0b0b0",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e0e0e01e",
+    "layer1.tint": "#b0b0b0",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b0b0b0",
+    "layer2.tint": "#d0d0d0",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b0b0b0",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#d0d0d0",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3030301e",
+    "layer0.tint": "#b0b0b01e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#202020",
+    "fg": "#303030",
     "match_fg": "#f4bf75",
-    "selected_fg": "#505050",
+    "selected_fg": "#303030",
     "selected_match_fg": "#f4bf75"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#202020",
+    "fg": "#303030",
     "match_fg": "#f4bf75",
-    "selected_fg": "#505050",
+    "selected_fg": "#303030",
     "selected_match_fg": "#f4bf75"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#202020",
-    "match_fg": "#303030",
-    "selected_fg": "#505050",
-    "selected_match_fg": "#505050"
+    "fg": "#505050",
+    "match_fg": "#f4bf75",
+    "selected_fg": "#303030",
+    "selected_match_fg": "#f4bf75"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#d0d0d0",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#202020",
     "match_fg": "#f4bf75",
-    "selected_fg": "transparent",
+    "selected_fg": "#151515",
     "selected_match_fg": "#f4bf75",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f5f5f5",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d0d0d0",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d0d0d0",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#d0d0d0",
+    "color_scheme_tint": "#d0d0d0",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-codeschool.sublime-theme
+++ b/base16-codeschool.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1c3657",
+    "layer1.tint": "#3f4944",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#3f4944",
+    "layer2.tint": "#2a343a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#3f4944",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#3f4944",
+    "layer0.tint": "#2a343a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#9ea7a63f",
+    "layer0.tint": "#3f49443f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#a7cfa3",
     "match_fg": "#a03b1e",
-    "selected_fg": "#84898c",
+    "selected_fg": "#b5d8f6",
     "selected_match_fg": "#a03b1e"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#a7cfa3",
     "match_fg": "#a03b1e",
-    "selected_fg": "#84898c",
+    "selected_fg": "#b5d8f6",
     "selected_match_fg": "#a03b1e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#a7cfa3",
-    "match_fg": "#9ea7a6",
-    "selected_fg": "#84898c",
-    "selected_match_fg": "#84898c"
+    "fg": "#84898c",
+    "match_fg": "#a03b1e",
+    "selected_fg": "#9ea7a6",
+    "selected_match_fg": "#a03b1e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#3f4944",
+    "layer0.tint": "#2a343a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#a7cfa3",
     "match_fg": "#a03b1e",
-    "selected_fg": "transparent",
+    "selected_fg": "#b5d8f6",
     "selected_match_fg": "#a03b1e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#232c31",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2a343a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2a343a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#3f4944",
+    "layer0.tint": "#2a343a",
+    "color_scheme_tint": "#2a343a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-colors.sublime-theme
+++ b/base16-colors.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#333333",
+    "layer1.tint": "#777777",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#777777",
+    "layer2.tint": "#555555",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#777777",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#555555",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#bbbbbb3f",
+    "layer0.tint": "#7777773f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dddddd",
     "match_fg": "#ffdc00",
-    "selected_fg": "#999999",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffdc00"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dddddd",
     "match_fg": "#ffdc00",
-    "selected_fg": "#999999",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffdc00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dddddd",
-    "match_fg": "#bbbbbb",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "fg": "#999999",
+    "match_fg": "#ffdc00",
+    "selected_fg": "#bbbbbb",
+    "selected_match_fg": "#ffdc00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#777777",
+    "layer0.tint": "#555555",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dddddd",
     "match_fg": "#ffdc00",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffdc00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#111111",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#555555",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#555555",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#555555",
+    "color_scheme_tint": "#555555",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-cupcake.sublime-theme
+++ b/base16-cupcake.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d8d5dd",
+    "layer0.tint": "#bfb9c6",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f2f1f41e",
+    "layer1.tint": "#bfb9c6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#bfb9c6",
+    "layer2.tint": "#d8d5dd",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#bfb9c6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#bfb9c6",
+    "layer0.tint": "#d8d5dd",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8b81981e",
+    "layer0.tint": "#bfb9c61e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#72677e",
+    "fg": "#8b8198",
     "match_fg": "#dcb16c",
-    "selected_fg": "#a59daf",
+    "selected_fg": "#8b8198",
     "selected_match_fg": "#dcb16c"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#72677e",
+    "fg": "#8b8198",
     "match_fg": "#dcb16c",
-    "selected_fg": "#a59daf",
+    "selected_fg": "#8b8198",
     "selected_match_fg": "#dcb16c"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#72677e",
-    "match_fg": "#8b8198",
-    "selected_fg": "#a59daf",
-    "selected_match_fg": "#a59daf"
+    "fg": "#a59daf",
+    "match_fg": "#dcb16c",
+    "selected_fg": "#8b8198",
+    "selected_match_fg": "#dcb16c"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#bfb9c6",
+    "layer0.tint": "#d8d5dd",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#72677e",
     "match_fg": "#dcb16c",
-    "selected_fg": "transparent",
+    "selected_fg": "#585062",
     "selected_match_fg": "#dcb16c",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fbf1f2",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d8d5dd",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d8d5dd",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#bfb9c6",
+    "layer0.tint": "#d8d5dd",
+    "color_scheme_tint": "#d8d5dd",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-cupertino.sublime-theme
+++ b/base16-cupertino.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#808080",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#c0c0c01e",
+    "layer1.tint": "#808080",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#808080",
+    "layer2.tint": "#c0c0c0",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#808080",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#c0c0c0",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4040401e",
+    "layer0.tint": "#8080801e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#404040",
     "match_fg": "#826b28",
-    "selected_fg": "#808080",
+    "selected_fg": "#404040",
     "selected_match_fg": "#826b28"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#404040",
     "match_fg": "#826b28",
-    "selected_fg": "#808080",
+    "selected_fg": "#404040",
     "selected_match_fg": "#826b28"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#404040",
-    "match_fg": "#404040",
-    "selected_fg": "#808080",
-    "selected_match_fg": "#808080"
+    "fg": "#808080",
+    "match_fg": "#826b28",
+    "selected_fg": "#404040",
+    "selected_match_fg": "#826b28"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#808080",
+    "layer0.tint": "#c0c0c0",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#404040",
     "match_fg": "#826b28",
-    "selected_fg": "transparent",
+    "selected_fg": "#5e5e5e",
     "selected_match_fg": "#826b28",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#c0c0c0",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#c0c0c0",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#c0c0c0",
+    "color_scheme_tint": "#c0c0c0",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-da-one-black.sublime-theme
+++ b/base16-da-one-black.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#282828",
+    "layer1.tint": "#888888",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#888888",
+    "layer2.tint": "#585858",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#888888",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#888888",
+    "layer0.tint": "#585858",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ffffff3f",
+    "layer0.tint": "#8888883f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "#c8c8c8",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "#c8c8c8",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffffff",
-    "match_fg": "#ffffff",
-    "selected_fg": "#c8c8c8",
-    "selected_match_fg": "#c8c8c8"
+    "fg": "#c8c8c8",
+    "match_fg": "#ff9470",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#ff9470"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#888888",
+    "layer0.tint": "#585858",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#585858",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#585858",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#888888",
+    "layer0.tint": "#585858",
+    "color_scheme_tint": "#585858",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-da-one-gray.sublime-theme
+++ b/base16-da-one-gray.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#282828",
+    "layer1.tint": "#888888",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#888888",
+    "layer2.tint": "#585858",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#888888",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#888888",
+    "layer0.tint": "#585858",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ffffff3f",
+    "layer0.tint": "#8888883f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "#c8c8c8",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "#c8c8c8",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffffff",
-    "match_fg": "#ffffff",
-    "selected_fg": "#c8c8c8",
-    "selected_match_fg": "#c8c8c8"
+    "fg": "#c8c8c8",
+    "match_fg": "#ff9470",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#ff9470"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#888888",
+    "layer0.tint": "#585858",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#181818",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#585858",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#585858",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#888888",
+    "layer0.tint": "#585858",
+    "color_scheme_tint": "#585858",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-da-one-ocean.sublime-theme
+++ b/base16-da-one-ocean.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#22273d",
+    "layer1.tint": "#878d96",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#878d96",
+    "layer2.tint": "#525866",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#878d96",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#878d96",
+    "layer0.tint": "#525866",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ffffff3f",
+    "layer0.tint": "#878d963f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "#c8c8c8",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "#c8c8c8",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffffff",
-    "match_fg": "#ffffff",
-    "selected_fg": "#c8c8c8",
-    "selected_match_fg": "#c8c8c8"
+    "fg": "#c8c8c8",
+    "match_fg": "#ff9470",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#ff9470"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#878d96",
+    "layer0.tint": "#525866",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#171726",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#525866",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#525866",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#878d96",
+    "layer0.tint": "#525866",
+    "color_scheme_tint": "#525866",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-da-one-paper.sublime-theme
+++ b/base16-da-one-paper.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#888888",
+    "layer0.tint": "#585858",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#c8c8c81e",
+    "layer1.tint": "#585858",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#585858",
+    "layer2.tint": "#888888",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#585858",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#585858",
+    "layer0.tint": "#888888",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#1818181e",
+    "layer0.tint": "#5858581e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#000000",
+    "fg": "#181818",
     "match_fg": "#b3684f",
-    "selected_fg": "#282828",
+    "selected_fg": "#181818",
     "selected_match_fg": "#b3684f"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#000000",
+    "fg": "#181818",
     "match_fg": "#b3684f",
-    "selected_fg": "#282828",
+    "selected_fg": "#181818",
     "selected_match_fg": "#b3684f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#000000",
-    "match_fg": "#181818",
-    "selected_fg": "#282828",
-    "selected_match_fg": "#282828"
+    "fg": "#282828",
+    "match_fg": "#b3684f",
+    "selected_fg": "#181818",
+    "selected_match_fg": "#b3684f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#585858",
+    "layer0.tint": "#888888",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#000000",
     "match_fg": "#b3684f",
-    "selected_fg": "transparent",
+    "selected_fg": "#000000",
     "selected_match_fg": "#b3684f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#faf0dc",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#888888",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#888888",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#585858",
+    "layer0.tint": "#888888",
+    "color_scheme_tint": "#888888",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-da-one-sea.sublime-theme
+++ b/base16-da-one-sea.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#374059",
+    "layer1.tint": "#878d96",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#878d96",
+    "layer2.tint": "#525866",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#878d96",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#878d96",
+    "layer0.tint": "#525866",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ffffff3f",
+    "layer0.tint": "#878d963f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "#c8c8c8",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "#c8c8c8",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffffff",
-    "match_fg": "#ffffff",
-    "selected_fg": "#c8c8c8",
-    "selected_match_fg": "#c8c8c8"
+    "fg": "#c8c8c8",
+    "match_fg": "#ff9470",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#ff9470"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#878d96",
+    "layer0.tint": "#525866",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffffff",
     "match_fg": "#ff9470",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff9470",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#22273d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#525866",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#525866",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#878d96",
+    "layer0.tint": "#525866",
+    "color_scheme_tint": "#525866",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-da-one-white.sublime-theme
+++ b/base16-da-one-white.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#888888",
+    "layer0.tint": "#585858",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#c8c8c81e",
+    "layer1.tint": "#585858",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#585858",
+    "layer2.tint": "#888888",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#585858",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#585858",
+    "layer0.tint": "#888888",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#1818181e",
+    "layer0.tint": "#5858581e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#000000",
+    "fg": "#181818",
     "match_fg": "#b3684f",
-    "selected_fg": "#282828",
+    "selected_fg": "#181818",
     "selected_match_fg": "#b3684f"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#000000",
+    "fg": "#181818",
     "match_fg": "#b3684f",
-    "selected_fg": "#282828",
+    "selected_fg": "#181818",
     "selected_match_fg": "#b3684f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#000000",
-    "match_fg": "#181818",
-    "selected_fg": "#282828",
-    "selected_match_fg": "#282828"
+    "fg": "#282828",
+    "match_fg": "#b3684f",
+    "selected_fg": "#181818",
+    "selected_match_fg": "#b3684f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#585858",
+    "layer0.tint": "#888888",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#000000",
     "match_fg": "#b3684f",
-    "selected_fg": "transparent",
+    "selected_fg": "#000000",
     "selected_match_fg": "#b3684f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#888888",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#888888",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#585858",
+    "layer0.tint": "#888888",
+    "color_scheme_tint": "#888888",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-danqing-light.sublime-theme
+++ b/base16-danqing-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#e0f0ef",
+    "layer0.tint": "#cad8d2",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ecf6f21e",
+    "layer1.tint": "#cad8d2",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#cad8d2",
+    "layer2.tint": "#e0f0ef",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#cad8d2",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#cad8d2",
+    "layer0.tint": "#e0f0ef",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5a605d1e",
+    "layer0.tint": "#cad8d21e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#434846",
+    "fg": "#5a605d",
     "match_fg": "#f0c239",
-    "selected_fg": "#9da8a3",
+    "selected_fg": "#5a605d",
     "selected_match_fg": "#f0c239"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#434846",
+    "fg": "#5a605d",
     "match_fg": "#f0c239",
-    "selected_fg": "#9da8a3",
+    "selected_fg": "#5a605d",
     "selected_match_fg": "#f0c239"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#434846",
-    "match_fg": "#5a605d",
-    "selected_fg": "#9da8a3",
-    "selected_match_fg": "#9da8a3"
+    "fg": "#9da8a3",
+    "match_fg": "#f0c239",
+    "selected_fg": "#5a605d",
+    "selected_match_fg": "#f0c239"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#cad8d2",
+    "layer0.tint": "#e0f0ef",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#434846",
     "match_fg": "#f0c239",
-    "selected_fg": "transparent",
+    "selected_fg": "#2d302f",
     "selected_match_fg": "#f0c239",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fcfefd",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#e0f0ef",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#e0f0ef",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#cad8d2",
+    "layer0.tint": "#e0f0ef",
+    "color_scheme_tint": "#e0f0ef",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-danqing.sublime-theme
+++ b/base16-danqing.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#434846",
+    "layer1.tint": "#9da8a3",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9da8a3",
+    "layer2.tint": "#5a605d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9da8a3",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9da8a3",
+    "layer0.tint": "#5a605d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e0f0ef3f",
+    "layer0.tint": "#9da8a33f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ecf6f2",
     "match_fg": "#f0c239",
-    "selected_fg": "#cad8d2",
+    "selected_fg": "#fcfefd",
     "selected_match_fg": "#f0c239"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ecf6f2",
     "match_fg": "#f0c239",
-    "selected_fg": "#cad8d2",
+    "selected_fg": "#fcfefd",
     "selected_match_fg": "#f0c239"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ecf6f2",
-    "match_fg": "#e0f0ef",
-    "selected_fg": "#cad8d2",
-    "selected_match_fg": "#cad8d2"
+    "fg": "#cad8d2",
+    "match_fg": "#f0c239",
+    "selected_fg": "#e0f0ef",
+    "selected_match_fg": "#f0c239"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9da8a3",
+    "layer0.tint": "#5a605d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ecf6f2",
     "match_fg": "#f0c239",
-    "selected_fg": "transparent",
+    "selected_fg": "#fcfefd",
     "selected_match_fg": "#f0c239",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2d302f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5a605d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5a605d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9da8a3",
+    "layer0.tint": "#5a605d",
+    "color_scheme_tint": "#5a605d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-darcula.sublime-theme
+++ b/base16-darcula.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#323232",
+    "layer1.tint": "#606366",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#606366",
+    "layer2.tint": "#323232",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#606366",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#606366",
+    "layer0.tint": "#323232",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a9b7c63f",
+    "layer0.tint": "#6063663f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffc66d",
     "match_fg": "#bbb529",
-    "selected_fg": "#a4a3a3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#bbb529"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffc66d",
     "match_fg": "#bbb529",
-    "selected_fg": "#a4a3a3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#bbb529"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffc66d",
-    "match_fg": "#a9b7c6",
-    "selected_fg": "#a4a3a3",
-    "selected_match_fg": "#a4a3a3"
+    "fg": "#a4a3a3",
+    "match_fg": "#bbb529",
+    "selected_fg": "#a9b7c6",
+    "selected_match_fg": "#bbb529"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#606366",
+    "layer0.tint": "#323232",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffc66d",
     "match_fg": "#bbb529",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#bbb529",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2b2b2b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#323232",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#323232",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#606366",
+    "layer0.tint": "#323232",
+    "color_scheme_tint": "#323232",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-darkmoss.sublime-theme
+++ b/base16-darkmoss.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#252c2d",
+    "layer1.tint": "#555e5f",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#555e5f",
+    "layer2.tint": "#373c3d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#555e5f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#555e5f",
+    "layer0.tint": "#373c3d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c7c7a53f",
+    "layer0.tint": "#555e5f3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e3e3c8",
     "match_fg": "#fdb11f",
-    "selected_fg": "#818f80",
+    "selected_fg": "#e1eaef",
     "selected_match_fg": "#fdb11f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e3e3c8",
     "match_fg": "#fdb11f",
-    "selected_fg": "#818f80",
+    "selected_fg": "#e1eaef",
     "selected_match_fg": "#fdb11f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e3e3c8",
-    "match_fg": "#c7c7a5",
-    "selected_fg": "#818f80",
-    "selected_match_fg": "#818f80"
+    "fg": "#818f80",
+    "match_fg": "#fdb11f",
+    "selected_fg": "#c7c7a5",
+    "selected_match_fg": "#fdb11f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#555e5f",
+    "layer0.tint": "#373c3d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e3e3c8",
     "match_fg": "#fdb11f",
-    "selected_fg": "transparent",
+    "selected_fg": "#e1eaef",
     "selected_match_fg": "#fdb11f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#171e1f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#373c3d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#373c3d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#555e5f",
+    "layer0.tint": "#373c3d",
+    "color_scheme_tint": "#373c3d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-darktooth.sublime-theme
+++ b/base16-darktooth.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#32302f",
+    "layer1.tint": "#665c54",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#665c54",
+    "layer2.tint": "#504945",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a899843f",
+    "layer0.tint": "#665c543f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d5c4a1",
     "match_fg": "#fac03b",
-    "selected_fg": "#928374",
+    "selected_fg": "#fdf4c1",
     "selected_match_fg": "#fac03b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d5c4a1",
     "match_fg": "#fac03b",
-    "selected_fg": "#928374",
+    "selected_fg": "#fdf4c1",
     "selected_match_fg": "#fac03b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d5c4a1",
-    "match_fg": "#a89984",
-    "selected_fg": "#928374",
-    "selected_match_fg": "#928374"
+    "fg": "#928374",
+    "match_fg": "#fac03b",
+    "selected_fg": "#a89984",
+    "selected_match_fg": "#fac03b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d5c4a1",
     "match_fg": "#fac03b",
-    "selected_fg": "transparent",
+    "selected_fg": "#fdf4c1",
     "selected_match_fg": "#fac03b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1d2021",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
+    "color_scheme_tint": "#504945",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-darkviolet.sublime-theme
+++ b/base16-darkviolet.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#231a40",
+    "layer1.tint": "#593380",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#593380",
+    "layer2.tint": "#432d59",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#593380",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#593380",
+    "layer0.tint": "#432d59",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b08ae63f",
+    "layer0.tint": "#5933803f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#9045e6",
     "match_fg": "#f29df2",
-    "selected_fg": "#00ff00",
+    "selected_fg": "#a366ff",
     "selected_match_fg": "#f29df2"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#9045e6",
     "match_fg": "#f29df2",
-    "selected_fg": "#00ff00",
+    "selected_fg": "#a366ff",
     "selected_match_fg": "#f29df2"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#9045e6",
-    "match_fg": "#b08ae6",
-    "selected_fg": "#00ff00",
-    "selected_match_fg": "#00ff00"
+    "fg": "#00ff00",
+    "match_fg": "#f29df2",
+    "selected_fg": "#b08ae6",
+    "selected_match_fg": "#f29df2"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#593380",
+    "layer0.tint": "#432d59",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#9045e6",
     "match_fg": "#f29df2",
-    "selected_fg": "transparent",
+    "selected_fg": "#a366ff",
     "selected_match_fg": "#f29df2",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#432d59",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#432d59",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#593380",
+    "layer0.tint": "#432d59",
+    "color_scheme_tint": "#432d59",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-decaf.sublime-theme
+++ b/base16-decaf.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#393939",
+    "layer1.tint": "#777777",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#777777",
+    "layer2.tint": "#515151",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#777777",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#515151",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cccccc3f",
+    "layer0.tint": "#7777773f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#ffd67c",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffd67c"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#ffd67c",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffd67c"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#cccccc",
-    "selected_fg": "#b4b7b4",
-    "selected_match_fg": "#b4b7b4"
+    "fg": "#b4b7b4",
+    "match_fg": "#ffd67c",
+    "selected_fg": "#cccccc",
+    "selected_match_fg": "#ffd67c"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#777777",
+    "layer0.tint": "#515151",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#ffd67c",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffd67c",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2d2d2d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#515151",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#515151",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#515151",
+    "color_scheme_tint": "#515151",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-default-dark.sublime-theme
+++ b/base16-default-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#282828",
+    "layer1.tint": "#585858",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#585858",
+    "layer2.tint": "#383838",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#585858",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#585858",
+    "layer0.tint": "#383838",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d8d8d83f",
+    "layer0.tint": "#5858583f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e8e8",
     "match_fg": "#f7ca88",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#f7ca88"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e8e8",
     "match_fg": "#f7ca88",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#f7ca88"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e8e8",
-    "match_fg": "#d8d8d8",
-    "selected_fg": "#b8b8b8",
-    "selected_match_fg": "#b8b8b8"
+    "fg": "#b8b8b8",
+    "match_fg": "#f7ca88",
+    "selected_fg": "#d8d8d8",
+    "selected_match_fg": "#f7ca88"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#585858",
+    "layer0.tint": "#383838",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e8e8",
     "match_fg": "#f7ca88",
-    "selected_fg": "transparent",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#f7ca88",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#181818",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#383838",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#383838",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#585858",
+    "layer0.tint": "#383838",
+    "color_scheme_tint": "#383838",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-default-light.sublime-theme
+++ b/base16-default-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d8d8d8",
+    "layer0.tint": "#b8b8b8",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e8e8e81e",
+    "layer1.tint": "#b8b8b8",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b8b8b8",
+    "layer2.tint": "#d8d8d8",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b8b8b8",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3838381e",
+    "layer0.tint": "#b8b8b81e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#282828",
+    "fg": "#383838",
     "match_fg": "#f7ca88",
-    "selected_fg": "#585858",
+    "selected_fg": "#383838",
     "selected_match_fg": "#f7ca88"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#282828",
+    "fg": "#383838",
     "match_fg": "#f7ca88",
-    "selected_fg": "#585858",
+    "selected_fg": "#383838",
     "selected_match_fg": "#f7ca88"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#282828",
-    "match_fg": "#383838",
-    "selected_fg": "#585858",
-    "selected_match_fg": "#585858"
+    "fg": "#585858",
+    "match_fg": "#f7ca88",
+    "selected_fg": "#383838",
+    "selected_match_fg": "#f7ca88"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#282828",
     "match_fg": "#f7ca88",
-    "selected_fg": "transparent",
+    "selected_fg": "#181818",
     "selected_match_fg": "#f7ca88",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f8f8f8",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d8d8d8",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d8d8d8",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
+    "color_scheme_tint": "#d8d8d8",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-dirtysea.sublime-theme
+++ b/base16-dirtysea.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d0d0d0",
+    "layer0.tint": "#707070",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#d0dad01e",
+    "layer1.tint": "#707070",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#707070",
+    "layer2.tint": "#d0d0d0",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#707070",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#707070",
+    "layer0.tint": "#d0d0d0",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#0000001e",
+    "layer0.tint": "#7070701e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#f8f8f8",
+    "fg": "#000000",
     "match_fg": "#755b00",
-    "selected_fg": "#202020",
+    "selected_fg": "#000000",
     "selected_match_fg": "#755b00"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#f8f8f8",
+    "fg": "#000000",
     "match_fg": "#755b00",
-    "selected_fg": "#202020",
+    "selected_fg": "#000000",
     "selected_match_fg": "#755b00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f8f8f8",
-    "match_fg": "#000000",
-    "selected_fg": "#202020",
-    "selected_match_fg": "#202020"
+    "fg": "#202020",
+    "match_fg": "#755b00",
+    "selected_fg": "#000000",
+    "selected_match_fg": "#755b00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#707070",
+    "layer0.tint": "#d0d0d0",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f8f8f8",
     "match_fg": "#755b00",
-    "selected_fg": "transparent",
+    "selected_fg": "#c4d9c4",
     "selected_match_fg": "#755b00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#e0e0e0",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d0d0d0",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d0d0d0",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#707070",
+    "layer0.tint": "#d0d0d0",
+    "color_scheme_tint": "#d0d0d0",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-dracula.sublime-theme
+++ b/base16-dracula.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3a3c4e",
+    "layer1.tint": "#626483",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#626483",
+    "layer2.tint": "#4d4f68",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#626483",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#626483",
+    "layer0.tint": "#4d4f68",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e9e9f43f",
+    "layer0.tint": "#6264833f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f1f2f8",
     "match_fg": "#00f769",
-    "selected_fg": "#62d6e8",
+    "selected_fg": "#f7f7fb",
     "selected_match_fg": "#00f769"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f1f2f8",
     "match_fg": "#00f769",
-    "selected_fg": "#62d6e8",
+    "selected_fg": "#f7f7fb",
     "selected_match_fg": "#00f769"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f1f2f8",
-    "match_fg": "#e9e9f4",
-    "selected_fg": "#62d6e8",
-    "selected_match_fg": "#62d6e8"
+    "fg": "#62d6e8",
+    "match_fg": "#00f769",
+    "selected_fg": "#e9e9f4",
+    "selected_match_fg": "#00f769"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#626483",
+    "layer0.tint": "#4d4f68",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f1f2f8",
     "match_fg": "#00f769",
-    "selected_fg": "transparent",
+    "selected_fg": "#f7f7fb",
     "selected_match_fg": "#00f769",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#282936",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4d4f68",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4d4f68",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#626483",
+    "layer0.tint": "#4d4f68",
+    "color_scheme_tint": "#4d4f68",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-edge-dark.sublime-theme
+++ b/base16-edge-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#88909f",
+    "layer1.tint": "#3e4249",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#3e4249",
+    "layer2.tint": "#b7bec9",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#3e4249",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#3e4249",
+    "layer0.tint": "#b7bec9",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b7bec93f",
+    "layer0.tint": "#3e42493f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d390e7",
     "match_fg": "#dbb774",
-    "selected_fg": "#73b3e7",
+    "selected_fg": "#3e4249",
     "selected_match_fg": "#dbb774"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d390e7",
     "match_fg": "#dbb774",
-    "selected_fg": "#73b3e7",
+    "selected_fg": "#3e4249",
     "selected_match_fg": "#dbb774"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d390e7",
-    "match_fg": "#b7bec9",
-    "selected_fg": "#73b3e7",
-    "selected_match_fg": "#73b3e7"
+    "fg": "#73b3e7",
+    "match_fg": "#dbb774",
+    "selected_fg": "#b7bec9",
+    "selected_match_fg": "#dbb774"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#3e4249",
+    "layer0.tint": "#b7bec9",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d390e7",
     "match_fg": "#dbb774",
-    "selected_fg": "transparent",
+    "selected_fg": "#3e4249",
     "selected_match_fg": "#dbb774",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#262729",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#b7bec9",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#b7bec9",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#3e4249",
+    "layer0.tint": "#b7bec9",
+    "color_scheme_tint": "#b7bec9",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-edge-light.sublime-theme
+++ b/base16-edge-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d69822",
+    "layer0.tint": "#5e646f",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#7c9f4b1e",
+    "layer1.tint": "#5e646f",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5e646f",
+    "layer2.tint": "#d69822",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5e646f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5e646f",
+    "layer0.tint": "#d69822",
     "layer0.opacity": 1.0
   },
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#b870ce",
+    "fg": "#5e646f",
     "match_fg": "#d69822",
-    "selected_fg": "#6587bf",
+    "selected_fg": "#5e646f",
     "selected_match_fg": "#d69822"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#b870ce",
+    "fg": "#5e646f",
     "match_fg": "#d69822",
-    "selected_fg": "#6587bf",
+    "selected_fg": "#5e646f",
     "selected_match_fg": "#d69822"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#b870ce",
-    "match_fg": "#5e646f",
-    "selected_fg": "#6587bf",
-    "selected_match_fg": "#6587bf"
+    "fg": "#6587bf",
+    "match_fg": "#d69822",
+    "selected_fg": "#5e646f",
+    "selected_match_fg": "#d69822"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5e646f",
+    "layer0.tint": "#d69822",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b870ce",
     "match_fg": "#d69822",
-    "selected_fg": "transparent",
+    "selected_fg": "#5e646f",
     "selected_match_fg": "#d69822",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fafafa",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d69822",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d69822",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5e646f",
+    "layer0.tint": "#d69822",
+    "color_scheme_tint": "#d69822",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-eighties.sublime-theme
+++ b/base16-eighties.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#393939",
+    "layer1.tint": "#747369",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#747369",
+    "layer2.tint": "#515151",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#747369",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#747369",
+    "layer0.tint": "#515151",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d3d0c83f",
+    "layer0.tint": "#7473693f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e6df",
     "match_fg": "#ffcc66",
-    "selected_fg": "#a09f93",
+    "selected_fg": "#f2f0ec",
     "selected_match_fg": "#ffcc66"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e6df",
     "match_fg": "#ffcc66",
-    "selected_fg": "#a09f93",
+    "selected_fg": "#f2f0ec",
     "selected_match_fg": "#ffcc66"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e6df",
-    "match_fg": "#d3d0c8",
-    "selected_fg": "#a09f93",
-    "selected_match_fg": "#a09f93"
+    "fg": "#a09f93",
+    "match_fg": "#ffcc66",
+    "selected_fg": "#d3d0c8",
+    "selected_match_fg": "#ffcc66"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#747369",
+    "layer0.tint": "#515151",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e6df",
     "match_fg": "#ffcc66",
-    "selected_fg": "transparent",
+    "selected_fg": "#f2f0ec",
     "selected_match_fg": "#ffcc66",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2d2d2d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#515151",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#515151",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#747369",
+    "layer0.tint": "#515151",
+    "color_scheme_tint": "#515151",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-embers-light.sublime-theme
+++ b/base16-embers-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#909aa3",
+    "layer0.tint": "#75808a",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#aeb6be1e",
+    "layer1.tint": "#75808a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#75808a",
+    "layer2.tint": "#909aa3",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#75808a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#75808a",
+    "layer0.tint": "#909aa3",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#323b431e",
+    "layer0.tint": "#75808a1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#20262c",
+    "fg": "#323b43",
     "match_fg": "#57826d",
-    "selected_fg": "#47505a",
+    "selected_fg": "#323b43",
     "selected_match_fg": "#57826d"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#20262c",
+    "fg": "#323b43",
     "match_fg": "#57826d",
-    "selected_fg": "#47505a",
+    "selected_fg": "#323b43",
     "selected_match_fg": "#57826d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#20262c",
-    "match_fg": "#323b43",
-    "selected_fg": "#47505a",
-    "selected_match_fg": "#47505a"
+    "fg": "#47505a",
+    "match_fg": "#57826d",
+    "selected_fg": "#323b43",
+    "selected_match_fg": "#57826d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#75808a",
+    "layer0.tint": "#909aa3",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#20262c",
     "match_fg": "#57826d",
-    "selected_fg": "transparent",
+    "selected_fg": "#0f1316",
     "selected_match_fg": "#57826d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#d1d6db",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#909aa3",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#909aa3",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#75808a",
+    "layer0.tint": "#909aa3",
+    "color_scheme_tint": "#909aa3",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-embers.sublime-theme
+++ b/base16-embers.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2c2620",
+    "layer1.tint": "#5a5047",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5a5047",
+    "layer2.tint": "#433b32",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5a5047",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5a5047",
+    "layer0.tint": "#433b32",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a39a903f",
+    "layer0.tint": "#5a50473f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#beb6ae",
     "match_fg": "#6d8257",
-    "selected_fg": "#8a8075",
+    "selected_fg": "#dbd6d1",
     "selected_match_fg": "#6d8257"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#beb6ae",
     "match_fg": "#6d8257",
-    "selected_fg": "#8a8075",
+    "selected_fg": "#dbd6d1",
     "selected_match_fg": "#6d8257"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#beb6ae",
-    "match_fg": "#a39a90",
-    "selected_fg": "#8a8075",
-    "selected_match_fg": "#8a8075"
+    "fg": "#8a8075",
+    "match_fg": "#6d8257",
+    "selected_fg": "#a39a90",
+    "selected_match_fg": "#6d8257"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5a5047",
+    "layer0.tint": "#433b32",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#beb6ae",
     "match_fg": "#6d8257",
-    "selected_fg": "transparent",
+    "selected_fg": "#dbd6d1",
     "selected_match_fg": "#6d8257",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#16130f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#433b32",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#433b32",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5a5047",
+    "layer0.tint": "#433b32",
+    "color_scheme_tint": "#433b32",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-emil.sublime-theme
+++ b/base16-emil.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#9e9eaf",
+    "layer0.tint": "#7c7c98",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#bebed21e",
+    "layer1.tint": "#7c7c98",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7c7c98",
+    "layer2.tint": "#9e9eaf",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7c7c98",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7c7c98",
+    "layer0.tint": "#9e9eaf",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3131451e",
+    "layer0.tint": "#7c7c981e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#22223a",
+    "fg": "#313145",
     "match_fg": "#ff669b",
-    "selected_fg": "#505063",
+    "selected_fg": "#313145",
     "selected_match_fg": "#ff669b"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#22223a",
+    "fg": "#313145",
     "match_fg": "#ff669b",
-    "selected_fg": "#505063",
+    "selected_fg": "#313145",
     "selected_match_fg": "#ff669b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#22223a",
-    "match_fg": "#313145",
-    "selected_fg": "#505063",
-    "selected_match_fg": "#505063"
+    "fg": "#505063",
+    "match_fg": "#ff669b",
+    "selected_fg": "#313145",
+    "selected_match_fg": "#ff669b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7c7c98",
+    "layer0.tint": "#9e9eaf",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#22223a",
     "match_fg": "#ff669b",
-    "selected_fg": "transparent",
+    "selected_fg": "#1a1a2f",
     "selected_match_fg": "#ff669b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#efefef",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#9e9eaf",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#9e9eaf",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7c7c98",
+    "layer0.tint": "#9e9eaf",
+    "color_scheme_tint": "#9e9eaf",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-equilibrium-dark.sublime-theme
+++ b/base16-equilibrium-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#181c22",
+    "layer1.tint": "#7b776e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7b776e",
+    "layer2.tint": "#22262d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7b776e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7b776e",
+    "layer0.tint": "#22262d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#afaba23f",
+    "layer0.tint": "#7b776e3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cac6bd",
     "match_fg": "#bb8801",
-    "selected_fg": "#949088",
+    "selected_fg": "#e7e2d9",
     "selected_match_fg": "#bb8801"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cac6bd",
     "match_fg": "#bb8801",
-    "selected_fg": "#949088",
+    "selected_fg": "#e7e2d9",
     "selected_match_fg": "#bb8801"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cac6bd",
-    "match_fg": "#afaba2",
-    "selected_fg": "#949088",
-    "selected_match_fg": "#949088"
+    "fg": "#949088",
+    "match_fg": "#bb8801",
+    "selected_fg": "#afaba2",
+    "selected_match_fg": "#bb8801"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7b776e",
+    "layer0.tint": "#22262d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cac6bd",
     "match_fg": "#bb8801",
-    "selected_fg": "transparent",
+    "selected_fg": "#e7e2d9",
     "selected_match_fg": "#bb8801",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0c1118",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#22262d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#22262d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7b776e",
+    "layer0.tint": "#22262d",
+    "color_scheme_tint": "#22262d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-equilibrium-gray-dark.sublime-theme
+++ b/base16-equilibrium-gray-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1b1b1b",
+    "layer1.tint": "#777777",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#777777",
+    "layer2.tint": "#262626",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#777777",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#262626",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ababab3f",
+    "layer0.tint": "#7777773f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c6c6c6",
     "match_fg": "#bb8801",
-    "selected_fg": "#919191",
+    "selected_fg": "#e2e2e2",
     "selected_match_fg": "#bb8801"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c6c6c6",
     "match_fg": "#bb8801",
-    "selected_fg": "#919191",
+    "selected_fg": "#e2e2e2",
     "selected_match_fg": "#bb8801"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c6c6c6",
-    "match_fg": "#ababab",
-    "selected_fg": "#919191",
-    "selected_match_fg": "#919191"
+    "fg": "#919191",
+    "match_fg": "#bb8801",
+    "selected_fg": "#ababab",
+    "selected_match_fg": "#bb8801"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#777777",
+    "layer0.tint": "#262626",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c6c6c6",
     "match_fg": "#bb8801",
-    "selected_fg": "transparent",
+    "selected_fg": "#e2e2e2",
     "selected_match_fg": "#bb8801",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#111111",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#262626",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#262626",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#262626",
+    "color_scheme_tint": "#262626",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-equilibrium-gray-light.sublime-theme
+++ b/base16-equilibrium-gray-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d4d4d4",
+    "layer0.tint": "#777777",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e2e2e21e",
+    "layer1.tint": "#777777",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#777777",
+    "layer2.tint": "#d4d4d4",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#777777",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#d4d4d4",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4747471e",
+    "layer0.tint": "#7777771e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#303030",
+    "fg": "#474747",
     "match_fg": "#9d6f00",
-    "selected_fg": "#5e5e5e",
+    "selected_fg": "#474747",
     "selected_match_fg": "#9d6f00"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#303030",
+    "fg": "#474747",
     "match_fg": "#9d6f00",
-    "selected_fg": "#5e5e5e",
+    "selected_fg": "#474747",
     "selected_match_fg": "#9d6f00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#303030",
-    "match_fg": "#474747",
-    "selected_fg": "#5e5e5e",
-    "selected_match_fg": "#5e5e5e"
+    "fg": "#5e5e5e",
+    "match_fg": "#9d6f00",
+    "selected_fg": "#474747",
+    "selected_match_fg": "#9d6f00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#777777",
+    "layer0.tint": "#d4d4d4",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#303030",
     "match_fg": "#9d6f00",
-    "selected_fg": "transparent",
+    "selected_fg": "#1b1b1b",
     "selected_match_fg": "#9d6f00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f1f1f1",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d4d4d4",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d4d4d4",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#d4d4d4",
+    "color_scheme_tint": "#d4d4d4",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-equilibrium-light.sublime-theme
+++ b/base16-equilibrium-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d8d4cb",
+    "layer0.tint": "#73777f",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e7e2d91e",
+    "layer1.tint": "#73777f",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#73777f",
+    "layer2.tint": "#d8d4cb",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#73777f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#73777f",
+    "layer0.tint": "#d8d4cb",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#43474e1e",
+    "layer0.tint": "#73777f1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#2c3138",
+    "fg": "#43474e",
     "match_fg": "#9d6f00",
-    "selected_fg": "#5a5f66",
+    "selected_fg": "#43474e",
     "selected_match_fg": "#9d6f00"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#2c3138",
+    "fg": "#43474e",
     "match_fg": "#9d6f00",
-    "selected_fg": "#5a5f66",
+    "selected_fg": "#43474e",
     "selected_match_fg": "#9d6f00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#2c3138",
-    "match_fg": "#43474e",
-    "selected_fg": "#5a5f66",
-    "selected_match_fg": "#5a5f66"
+    "fg": "#5a5f66",
+    "match_fg": "#9d6f00",
+    "selected_fg": "#43474e",
+    "selected_match_fg": "#9d6f00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#73777f",
+    "layer0.tint": "#d8d4cb",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#2c3138",
     "match_fg": "#9d6f00",
-    "selected_fg": "transparent",
+    "selected_fg": "#181c22",
     "selected_match_fg": "#9d6f00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f5f0e7",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d8d4cb",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d8d4cb",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#73777f",
+    "layer0.tint": "#d8d4cb",
+    "color_scheme_tint": "#d8d4cb",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-eris.sublime-theme
+++ b/base16-eris.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#13133a",
+    "layer1.tint": "#333773",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333773",
+    "layer2.tint": "#23255a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333773",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333773",
+    "layer0.tint": "#23255a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#606bac3f",
+    "layer0.tint": "#3337733f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#7986c5",
     "match_fg": "#faaea2",
-    "selected_fg": "#4a5293",
+    "selected_fg": "#9aaae5",
     "selected_match_fg": "#faaea2"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#7986c5",
     "match_fg": "#faaea2",
-    "selected_fg": "#4a5293",
+    "selected_fg": "#9aaae5",
     "selected_match_fg": "#faaea2"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#7986c5",
-    "match_fg": "#606bac",
-    "selected_fg": "#4a5293",
-    "selected_match_fg": "#4a5293"
+    "fg": "#4a5293",
+    "match_fg": "#faaea2",
+    "selected_fg": "#606bac",
+    "selected_match_fg": "#faaea2"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333773",
+    "layer0.tint": "#23255a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#7986c5",
     "match_fg": "#faaea2",
-    "selected_fg": "transparent",
+    "selected_fg": "#9aaae5",
     "selected_match_fg": "#faaea2",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0a0920",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#23255a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#23255a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333773",
+    "layer0.tint": "#23255a",
+    "color_scheme_tint": "#23255a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-espresso.sublime-theme
+++ b/base16-espresso.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#393939",
+    "layer1.tint": "#777777",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#777777",
+    "layer2.tint": "#515151",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#777777",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#515151",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cccccc3f",
+    "layer0.tint": "#7777773f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#ffc66d",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffc66d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#ffc66d",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffc66d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#cccccc",
-    "selected_fg": "#b4b7b4",
-    "selected_match_fg": "#b4b7b4"
+    "fg": "#b4b7b4",
+    "match_fg": "#ffc66d",
+    "selected_fg": "#cccccc",
+    "selected_match_fg": "#ffc66d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#777777",
+    "layer0.tint": "#515151",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#ffc66d",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffc66d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2d2d2d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#515151",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#515151",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#515151",
+    "color_scheme_tint": "#515151",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-eva-dim.sublime-theme
+++ b/base16-eva-dim.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3d566f",
+    "layer1.tint": "#55799c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#55799c",
+    "layer2.tint": "#4b6988",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#55799c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#55799c",
+    "layer0.tint": "#4b6988",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#9fa2a63f",
+    "layer0.tint": "#55799c3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d6d7d9",
     "match_fg": "#cfd05d",
-    "selected_fg": "#7e90a3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#cfd05d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d6d7d9",
     "match_fg": "#cfd05d",
-    "selected_fg": "#7e90a3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#cfd05d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d6d7d9",
-    "match_fg": "#9fa2a6",
-    "selected_fg": "#7e90a3",
-    "selected_match_fg": "#7e90a3"
+    "fg": "#7e90a3",
+    "match_fg": "#cfd05d",
+    "selected_fg": "#9fa2a6",
+    "selected_match_fg": "#cfd05d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#55799c",
+    "layer0.tint": "#4b6988",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d6d7d9",
     "match_fg": "#cfd05d",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#cfd05d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2a3b4d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4b6988",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4b6988",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#55799c",
+    "layer0.tint": "#4b6988",
+    "color_scheme_tint": "#4b6988",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-eva.sublime-theme
+++ b/base16-eva.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3d566f",
+    "layer1.tint": "#55799c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#55799c",
+    "layer2.tint": "#4b6988",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#55799c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#55799c",
+    "layer0.tint": "#4b6988",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#9fa2a63f",
+    "layer0.tint": "#55799c3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d6d7d9",
     "match_fg": "#ffff66",
-    "selected_fg": "#7e90a3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffff66"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d6d7d9",
     "match_fg": "#ffff66",
-    "selected_fg": "#7e90a3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffff66"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d6d7d9",
-    "match_fg": "#9fa2a6",
-    "selected_fg": "#7e90a3",
-    "selected_match_fg": "#7e90a3"
+    "fg": "#7e90a3",
+    "match_fg": "#ffff66",
+    "selected_fg": "#9fa2a6",
+    "selected_match_fg": "#ffff66"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#55799c",
+    "layer0.tint": "#4b6988",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d6d7d9",
     "match_fg": "#ffff66",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffff66",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2a3b4d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4b6988",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4b6988",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#55799c",
+    "layer0.tint": "#4b6988",
+    "color_scheme_tint": "#4b6988",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-evenok-dark.sublime-theme
+++ b/base16-evenok-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#202020",
+    "layer1.tint": "#505050",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#505050",
+    "layer2.tint": "#303030",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#505050",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0d0d03f",
+    "layer0.tint": "#5050503f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#b8a300",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#b8a300"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#b8a300",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#b8a300"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#d0d0d0",
-    "selected_fg": "#b0b0b0",
-    "selected_match_fg": "#b0b0b0"
+    "fg": "#b0b0b0",
+    "match_fg": "#b8a300",
+    "selected_fg": "#d0d0d0",
+    "selected_match_fg": "#b8a300"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#b8a300",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#b8a300",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
+    "color_scheme_tint": "#303030",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-everforest-dark-hard.sublime-theme
+++ b/base16-everforest-dark-hard.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2e383c",
+    "layer1.tint": "#859289",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#859289",
+    "layer2.tint": "#414b50",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#859289",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#859289",
+    "layer0.tint": "#414b50",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d3c6aa3f",
+    "layer0.tint": "#8592893f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#edeada",
     "match_fg": "#dbbc7f",
-    "selected_fg": "#9da9a0",
+    "selected_fg": "#fffbef",
     "selected_match_fg": "#dbbc7f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#edeada",
     "match_fg": "#dbbc7f",
-    "selected_fg": "#9da9a0",
+    "selected_fg": "#fffbef",
     "selected_match_fg": "#dbbc7f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#edeada",
-    "match_fg": "#d3c6aa",
-    "selected_fg": "#9da9a0",
-    "selected_match_fg": "#9da9a0"
+    "fg": "#9da9a0",
+    "match_fg": "#dbbc7f",
+    "selected_fg": "#d3c6aa",
+    "selected_match_fg": "#dbbc7f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#859289",
+    "layer0.tint": "#414b50",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#edeada",
     "match_fg": "#dbbc7f",
-    "selected_fg": "transparent",
+    "selected_fg": "#fffbef",
     "selected_match_fg": "#dbbc7f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#272e33",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#414b50",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#414b50",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#859289",
+    "layer0.tint": "#414b50",
+    "color_scheme_tint": "#414b50",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-everforest.sublime-theme
+++ b/base16-everforest.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#343f44",
+    "layer1.tint": "#859289",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#859289",
+    "layer2.tint": "#475258",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#859289",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#859289",
+    "layer0.tint": "#475258",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d3c6aa3f",
+    "layer0.tint": "#8592893f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e6e2cc",
     "match_fg": "#dbbc7f",
-    "selected_fg": "#9da9a0",
+    "selected_fg": "#fdf6e3",
     "selected_match_fg": "#dbbc7f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e6e2cc",
     "match_fg": "#dbbc7f",
-    "selected_fg": "#9da9a0",
+    "selected_fg": "#fdf6e3",
     "selected_match_fg": "#dbbc7f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e6e2cc",
-    "match_fg": "#d3c6aa",
-    "selected_fg": "#9da9a0",
-    "selected_match_fg": "#9da9a0"
+    "fg": "#9da9a0",
+    "match_fg": "#dbbc7f",
+    "selected_fg": "#d3c6aa",
+    "selected_match_fg": "#dbbc7f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#859289",
+    "layer0.tint": "#475258",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e6e2cc",
     "match_fg": "#dbbc7f",
-    "selected_fg": "transparent",
+    "selected_fg": "#fdf6e3",
     "selected_match_fg": "#dbbc7f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2d353b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#475258",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#475258",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#859289",
+    "layer0.tint": "#475258",
+    "color_scheme_tint": "#475258",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-flat.sublime-theme
+++ b/base16-flat.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#34495e",
+    "layer1.tint": "#95a5a6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#95a5a6",
+    "layer2.tint": "#7f8c8d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#95a5a6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#95a5a6",
+    "layer0.tint": "#7f8c8d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e0e0e03f",
+    "layer0.tint": "#95a5a63f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f5f5f5",
     "match_fg": "#f1c40f",
-    "selected_fg": "#bdc3c7",
+    "selected_fg": "#ecf0f1",
     "selected_match_fg": "#f1c40f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f5f5f5",
     "match_fg": "#f1c40f",
-    "selected_fg": "#bdc3c7",
+    "selected_fg": "#ecf0f1",
     "selected_match_fg": "#f1c40f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f5f5f5",
-    "match_fg": "#e0e0e0",
-    "selected_fg": "#bdc3c7",
-    "selected_match_fg": "#bdc3c7"
+    "fg": "#bdc3c7",
+    "match_fg": "#f1c40f",
+    "selected_fg": "#e0e0e0",
+    "selected_match_fg": "#f1c40f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#95a5a6",
+    "layer0.tint": "#7f8c8d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f5f5f5",
     "match_fg": "#f1c40f",
-    "selected_fg": "transparent",
+    "selected_fg": "#ecf0f1",
     "selected_match_fg": "#f1c40f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2c3e50",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#7f8c8d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#7f8c8d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#95a5a6",
+    "layer0.tint": "#7f8c8d",
+    "color_scheme_tint": "#7f8c8d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-framer.sublime-theme
+++ b/base16-framer.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#151515",
+    "layer1.tint": "#747474",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#747474",
+    "layer2.tint": "#464646",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#747474",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#747474",
+    "layer0.tint": "#464646",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0d0d03f",
+    "layer0.tint": "#7474743f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e8e8",
     "match_fg": "#fecb6e",
-    "selected_fg": "#b9b9b9",
+    "selected_fg": "#eeeeee",
     "selected_match_fg": "#fecb6e"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e8e8",
     "match_fg": "#fecb6e",
-    "selected_fg": "#b9b9b9",
+    "selected_fg": "#eeeeee",
     "selected_match_fg": "#fecb6e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e8e8",
-    "match_fg": "#d0d0d0",
-    "selected_fg": "#b9b9b9",
-    "selected_match_fg": "#b9b9b9"
+    "fg": "#b9b9b9",
+    "match_fg": "#fecb6e",
+    "selected_fg": "#d0d0d0",
+    "selected_match_fg": "#fecb6e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#747474",
+    "layer0.tint": "#464646",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e8e8",
     "match_fg": "#fecb6e",
-    "selected_fg": "transparent",
+    "selected_fg": "#eeeeee",
     "selected_match_fg": "#fecb6e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#181818",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#464646",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#464646",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#747474",
+    "layer0.tint": "#464646",
+    "color_scheme_tint": "#464646",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-fruit-soda.sublime-theme
+++ b/base16-fruit-soda.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d8d5d5",
+    "layer0.tint": "#b5b4b6",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e0dee01e",
+    "layer1.tint": "#b5b4b6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b5b4b6",
+    "layer2.tint": "#d8d5d5",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b5b4b6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b5b4b6",
+    "layer0.tint": "#d8d5d5",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5151511e",
+    "layer0.tint": "#b5b4b61e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#474545",
+    "fg": "#515151",
     "match_fg": "#f7e203",
-    "selected_fg": "#979598",
+    "selected_fg": "#515151",
     "selected_match_fg": "#f7e203"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#474545",
+    "fg": "#515151",
     "match_fg": "#f7e203",
-    "selected_fg": "#979598",
+    "selected_fg": "#515151",
     "selected_match_fg": "#f7e203"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#474545",
-    "match_fg": "#515151",
-    "selected_fg": "#979598",
-    "selected_match_fg": "#979598"
+    "fg": "#979598",
+    "match_fg": "#f7e203",
+    "selected_fg": "#515151",
+    "selected_match_fg": "#f7e203"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b5b4b6",
+    "layer0.tint": "#d8d5d5",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#474545",
     "match_fg": "#f7e203",
-    "selected_fg": "transparent",
+    "selected_fg": "#2d2c2c",
     "selected_match_fg": "#f7e203",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f1ecf1",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d8d5d5",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d8d5d5",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b5b4b6",
+    "layer0.tint": "#d8d5d5",
+    "color_scheme_tint": "#d8d5d5",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gigavolt.sublime-theme
+++ b/base16-gigavolt.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2d303d",
+    "layer1.tint": "#a1d2e6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#a1d2e6",
+    "layer2.tint": "#5a576e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#a1d2e6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#a1d2e6",
+    "layer0.tint": "#5a576e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e9e7e13f",
+    "layer0.tint": "#a1d2e63f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#eff0f9",
     "match_fg": "#ffdc2d",
-    "selected_fg": "#cad3ff",
+    "selected_fg": "#f2fbff",
     "selected_match_fg": "#ffdc2d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#eff0f9",
     "match_fg": "#ffdc2d",
-    "selected_fg": "#cad3ff",
+    "selected_fg": "#f2fbff",
     "selected_match_fg": "#ffdc2d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#eff0f9",
-    "match_fg": "#e9e7e1",
-    "selected_fg": "#cad3ff",
-    "selected_match_fg": "#cad3ff"
+    "fg": "#cad3ff",
+    "match_fg": "#ffdc2d",
+    "selected_fg": "#e9e7e1",
+    "selected_match_fg": "#ffdc2d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#a1d2e6",
+    "layer0.tint": "#5a576e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eff0f9",
     "match_fg": "#ffdc2d",
-    "selected_fg": "transparent",
+    "selected_fg": "#f2fbff",
     "selected_match_fg": "#ffdc2d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#202126",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5a576e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5a576e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#a1d2e6",
+    "layer0.tint": "#5a576e",
+    "color_scheme_tint": "#5a576e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-github.sublime-theme
+++ b/base16-github.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#c8c8fa",
+    "layer0.tint": "#969896",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f5f5f51e",
+    "layer1.tint": "#969896",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#969896",
+    "layer2.tint": "#c8c8fa",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#969896",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#969896",
+    "layer0.tint": "#c8c8fa",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3333331e",
+    "layer0.tint": "#9698961e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#ffffff",
+    "fg": "#333333",
     "match_fg": "#795da3",
-    "selected_fg": "#e8e8e8",
+    "selected_fg": "#333333",
     "selected_match_fg": "#795da3"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#ffffff",
+    "fg": "#333333",
     "match_fg": "#795da3",
-    "selected_fg": "#e8e8e8",
+    "selected_fg": "#333333",
     "selected_match_fg": "#795da3"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffffff",
-    "match_fg": "#333333",
-    "selected_fg": "#e8e8e8",
-    "selected_match_fg": "#e8e8e8"
+    "fg": "#e8e8e8",
+    "match_fg": "#795da3",
+    "selected_fg": "#333333",
+    "selected_match_fg": "#795da3"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#969896",
+    "layer0.tint": "#c8c8fa",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffffff",
     "match_fg": "#795da3",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#795da3",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#c8c8fa",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#c8c8fa",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#969896",
+    "layer0.tint": "#c8c8fa",
+    "color_scheme_tint": "#c8c8fa",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-google-dark.sublime-theme
+++ b/base16-google-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#282a2e",
+    "layer1.tint": "#969896",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#969896",
+    "layer2.tint": "#373b41",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#969896",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#969896",
+    "layer0.tint": "#373b41",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c5c8c63f",
+    "layer0.tint": "#9698963f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#fba922",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fba922"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#fba922",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fba922"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#c5c8c6",
-    "selected_fg": "#b4b7b4",
-    "selected_match_fg": "#b4b7b4"
+    "fg": "#b4b7b4",
+    "match_fg": "#fba922",
+    "selected_fg": "#c5c8c6",
+    "selected_match_fg": "#fba922"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#969896",
+    "layer0.tint": "#373b41",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#fba922",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fba922",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1d1f21",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#373b41",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#373b41",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#969896",
+    "layer0.tint": "#373b41",
+    "color_scheme_tint": "#373b41",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-google-light.sublime-theme
+++ b/base16-google-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#c5c8c6",
+    "layer0.tint": "#b4b7b4",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e0e0e01e",
+    "layer1.tint": "#b4b7b4",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b4b7b4",
+    "layer2.tint": "#c5c8c6",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b4b7b4",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b4b7b4",
+    "layer0.tint": "#c5c8c6",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#373b411e",
+    "layer0.tint": "#b4b7b41e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#282a2e",
+    "fg": "#373b41",
     "match_fg": "#fba922",
-    "selected_fg": "#969896",
+    "selected_fg": "#373b41",
     "selected_match_fg": "#fba922"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#282a2e",
+    "fg": "#373b41",
     "match_fg": "#fba922",
-    "selected_fg": "#969896",
+    "selected_fg": "#373b41",
     "selected_match_fg": "#fba922"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#282a2e",
-    "match_fg": "#373b41",
-    "selected_fg": "#969896",
-    "selected_match_fg": "#969896"
+    "fg": "#969896",
+    "match_fg": "#fba922",
+    "selected_fg": "#373b41",
+    "selected_match_fg": "#fba922"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b4b7b4",
+    "layer0.tint": "#c5c8c6",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#282a2e",
     "match_fg": "#fba922",
-    "selected_fg": "transparent",
+    "selected_fg": "#1d1f21",
     "selected_match_fg": "#fba922",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#c5c8c6",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#c5c8c6",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b4b7b4",
+    "layer0.tint": "#c5c8c6",
+    "color_scheme_tint": "#c5c8c6",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gotham.sublime-theme
+++ b/base16-gotham.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#11151c",
+    "layer1.tint": "#0a3749",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#0a3749",
+    "layer2.tint": "#091f2e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#0a3749",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#0a3749",
+    "layer0.tint": "#091f2e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#599cab3f",
+    "layer0.tint": "#0a37493f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#99d1ce",
     "match_fg": "#edb443",
-    "selected_fg": "#245361",
+    "selected_fg": "#d3ebe9",
     "selected_match_fg": "#edb443"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#99d1ce",
     "match_fg": "#edb443",
-    "selected_fg": "#245361",
+    "selected_fg": "#d3ebe9",
     "selected_match_fg": "#edb443"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#99d1ce",
-    "match_fg": "#599cab",
-    "selected_fg": "#245361",
-    "selected_match_fg": "#245361"
+    "fg": "#245361",
+    "match_fg": "#edb443",
+    "selected_fg": "#599cab",
+    "selected_match_fg": "#edb443"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#0a3749",
+    "layer0.tint": "#091f2e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#99d1ce",
     "match_fg": "#edb443",
-    "selected_fg": "transparent",
+    "selected_fg": "#d3ebe9",
     "selected_match_fg": "#edb443",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0c1014",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#091f2e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#091f2e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#0a3749",
+    "layer0.tint": "#091f2e",
+    "color_scheme_tint": "#091f2e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-grayscale-dark.sublime-theme
+++ b/base16-grayscale-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#252525",
+    "layer1.tint": "#525252",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#525252",
+    "layer2.tint": "#464646",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#525252",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#525252",
+    "layer0.tint": "#464646",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b9b9b93f",
+    "layer0.tint": "#5252523f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e3e3e3",
     "match_fg": "#a0a0a0",
-    "selected_fg": "#ababab",
+    "selected_fg": "#f7f7f7",
     "selected_match_fg": "#a0a0a0"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e3e3e3",
     "match_fg": "#a0a0a0",
-    "selected_fg": "#ababab",
+    "selected_fg": "#f7f7f7",
     "selected_match_fg": "#a0a0a0"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e3e3e3",
-    "match_fg": "#b9b9b9",
-    "selected_fg": "#ababab",
-    "selected_match_fg": "#ababab"
+    "fg": "#ababab",
+    "match_fg": "#a0a0a0",
+    "selected_fg": "#b9b9b9",
+    "selected_match_fg": "#a0a0a0"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#525252",
+    "layer0.tint": "#464646",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e3e3e3",
     "match_fg": "#a0a0a0",
-    "selected_fg": "transparent",
+    "selected_fg": "#f7f7f7",
     "selected_match_fg": "#a0a0a0",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#101010",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#464646",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#464646",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#525252",
+    "layer0.tint": "#464646",
+    "color_scheme_tint": "#464646",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-grayscale-light.sublime-theme
+++ b/base16-grayscale-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#b9b9b9",
+    "layer0.tint": "#ababab",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e3e3e31e",
+    "layer1.tint": "#ababab",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#ababab",
+    "layer2.tint": "#b9b9b9",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#ababab",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#ababab",
+    "layer0.tint": "#b9b9b9",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4646461e",
+    "layer0.tint": "#ababab1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#252525",
+    "fg": "#464646",
     "match_fg": "#a0a0a0",
-    "selected_fg": "#525252",
+    "selected_fg": "#464646",
     "selected_match_fg": "#a0a0a0"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#252525",
+    "fg": "#464646",
     "match_fg": "#a0a0a0",
-    "selected_fg": "#525252",
+    "selected_fg": "#464646",
     "selected_match_fg": "#a0a0a0"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#252525",
-    "match_fg": "#464646",
-    "selected_fg": "#525252",
-    "selected_match_fg": "#525252"
+    "fg": "#525252",
+    "match_fg": "#a0a0a0",
+    "selected_fg": "#464646",
+    "selected_match_fg": "#a0a0a0"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#ababab",
+    "layer0.tint": "#b9b9b9",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#252525",
     "match_fg": "#a0a0a0",
-    "selected_fg": "transparent",
+    "selected_fg": "#101010",
     "selected_match_fg": "#a0a0a0",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f7f7f7",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#b9b9b9",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#b9b9b9",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#ababab",
+    "layer0.tint": "#b9b9b9",
+    "color_scheme_tint": "#b9b9b9",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-greenscreen.sublime-theme
+++ b/base16-greenscreen.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#003300",
+    "layer1.tint": "#007700",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#007700",
+    "layer2.tint": "#005500",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#007700",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#007700",
+    "layer0.tint": "#005500",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#00bb003f",
+    "layer0.tint": "#0077003f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#00dd00",
     "match_fg": "#007700",
-    "selected_fg": "#009900",
+    "selected_fg": "#00ff00",
     "selected_match_fg": "#007700"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#00dd00",
     "match_fg": "#007700",
-    "selected_fg": "#009900",
+    "selected_fg": "#00ff00",
     "selected_match_fg": "#007700"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#00dd00",
-    "match_fg": "#00bb00",
-    "selected_fg": "#009900",
-    "selected_match_fg": "#009900"
+    "fg": "#009900",
+    "match_fg": "#007700",
+    "selected_fg": "#00bb00",
+    "selected_match_fg": "#007700"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#007700",
+    "layer0.tint": "#005500",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#00dd00",
     "match_fg": "#007700",
-    "selected_fg": "transparent",
+    "selected_fg": "#00ff00",
     "selected_match_fg": "#007700",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#001100",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#005500",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#005500",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#007700",
+    "layer0.tint": "#005500",
+    "color_scheme_tint": "#005500",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruber.sublime-theme
+++ b/base16-gruber.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#453d41",
+    "layer1.tint": "#52494e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#52494e",
+    "layer2.tint": "#484848",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#52494e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#52494e",
+    "layer0.tint": "#484848",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#f4f4ff3f",
+    "layer0.tint": "#52494e3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -641,10 +635,10 @@
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f5f5f5",
-    "match_fg": "#f4f4ff",
-    "selected_fg": "#e4e4ef",
-    "selected_match_fg": "#e4e4ef"
+    "fg": "#e4e4ef",
+    "match_fg": "#ffdd33",
+    "selected_fg": "#f4f4ff",
+    "selected_match_fg": "#ffdd33"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#52494e",
+    "layer0.tint": "#484848",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f5f5f5",
     "match_fg": "#ffdd33",
-    "selected_fg": "transparent",
+    "selected_fg": "#e4e4ef",
     "selected_match_fg": "#ffdd33",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#181818",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#484848",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#484848",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#52494e",
+    "layer0.tint": "#484848",
+    "color_scheme_tint": "#484848",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-dark-hard.sublime-theme
+++ b/base16-gruvbox-dark-hard.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3c3836",
+    "layer1.tint": "#665c54",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#665c54",
+    "layer2.tint": "#504945",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d5c4a13f",
+    "layer0.tint": "#665c543f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ebdbb2",
-    "match_fg": "#d5c4a1",
-    "selected_fg": "#bdae93",
-    "selected_match_fg": "#bdae93"
+    "fg": "#bdae93",
+    "match_fg": "#fabd2f",
+    "selected_fg": "#d5c4a1",
+    "selected_match_fg": "#fabd2f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "transparent",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1d2021",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
+    "color_scheme_tint": "#504945",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-dark-medium.sublime-theme
+++ b/base16-gruvbox-dark-medium.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3c3836",
+    "layer1.tint": "#665c54",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#665c54",
+    "layer2.tint": "#504945",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d5c4a13f",
+    "layer0.tint": "#665c543f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ebdbb2",
-    "match_fg": "#d5c4a1",
-    "selected_fg": "#bdae93",
-    "selected_match_fg": "#bdae93"
+    "fg": "#bdae93",
+    "match_fg": "#fabd2f",
+    "selected_fg": "#d5c4a1",
+    "selected_match_fg": "#fabd2f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "transparent",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#282828",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
+    "color_scheme_tint": "#504945",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-dark-pale.sublime-theme
+++ b/base16-gruvbox-dark-pale.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3a3a3a",
+    "layer1.tint": "#8a8a8a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#8a8a8a",
+    "layer2.tint": "#4e4e4e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#8a8a8a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#8a8a8a",
+    "layer0.tint": "#4e4e4e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#dab9973f",
+    "layer0.tint": "#8a8a8a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d5c4a1",
     "match_fg": "#ffaf00",
-    "selected_fg": "#949494",
+    "selected_fg": "#ebdbb2",
     "selected_match_fg": "#ffaf00"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d5c4a1",
     "match_fg": "#ffaf00",
-    "selected_fg": "#949494",
+    "selected_fg": "#ebdbb2",
     "selected_match_fg": "#ffaf00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d5c4a1",
-    "match_fg": "#dab997",
-    "selected_fg": "#949494",
-    "selected_match_fg": "#949494"
+    "fg": "#949494",
+    "match_fg": "#ffaf00",
+    "selected_fg": "#dab997",
+    "selected_match_fg": "#ffaf00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#8a8a8a",
+    "layer0.tint": "#4e4e4e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d5c4a1",
     "match_fg": "#ffaf00",
-    "selected_fg": "transparent",
+    "selected_fg": "#ebdbb2",
     "selected_match_fg": "#ffaf00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#262626",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4e4e4e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4e4e4e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#8a8a8a",
+    "layer0.tint": "#4e4e4e",
+    "color_scheme_tint": "#4e4e4e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-dark-soft.sublime-theme
+++ b/base16-gruvbox-dark-soft.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3c3836",
+    "layer1.tint": "#665c54",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#665c54",
+    "layer2.tint": "#504945",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d5c4a13f",
+    "layer0.tint": "#665c543f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ebdbb2",
-    "match_fg": "#d5c4a1",
-    "selected_fg": "#bdae93",
-    "selected_match_fg": "#bdae93"
+    "fg": "#bdae93",
+    "match_fg": "#fabd2f",
+    "selected_fg": "#d5c4a1",
+    "selected_match_fg": "#fabd2f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ebdbb2",
     "match_fg": "#fabd2f",
-    "selected_fg": "transparent",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#fabd2f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#32302f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
+    "color_scheme_tint": "#504945",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-light-hard.sublime-theme
+++ b/base16-gruvbox-light-hard.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d5c4a1",
+    "layer0.tint": "#bdae93",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ebdbb21e",
+    "layer1.tint": "#bdae93",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#bdae93",
+    "layer2.tint": "#d5c4a1",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#bdae93",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5049451e",
+    "layer0.tint": "#bdae931e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#3c3836",
+    "fg": "#504945",
     "match_fg": "#b57614",
-    "selected_fg": "#665c54",
+    "selected_fg": "#504945",
     "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#3c3836",
+    "fg": "#504945",
     "match_fg": "#b57614",
-    "selected_fg": "#665c54",
+    "selected_fg": "#504945",
     "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#3c3836",
-    "match_fg": "#504945",
-    "selected_fg": "#665c54",
-    "selected_match_fg": "#665c54"
+    "fg": "#665c54",
+    "match_fg": "#b57614",
+    "selected_fg": "#504945",
+    "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#3c3836",
     "match_fg": "#b57614",
-    "selected_fg": "transparent",
+    "selected_fg": "#282828",
     "selected_match_fg": "#b57614",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f9f5d7",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d5c4a1",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d5c4a1",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
+    "color_scheme_tint": "#d5c4a1",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-light-medium.sublime-theme
+++ b/base16-gruvbox-light-medium.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d5c4a1",
+    "layer0.tint": "#bdae93",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ebdbb21e",
+    "layer1.tint": "#bdae93",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#bdae93",
+    "layer2.tint": "#d5c4a1",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#bdae93",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5049451e",
+    "layer0.tint": "#bdae931e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#3c3836",
+    "fg": "#504945",
     "match_fg": "#b57614",
-    "selected_fg": "#665c54",
+    "selected_fg": "#504945",
     "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#3c3836",
+    "fg": "#504945",
     "match_fg": "#b57614",
-    "selected_fg": "#665c54",
+    "selected_fg": "#504945",
     "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#3c3836",
-    "match_fg": "#504945",
-    "selected_fg": "#665c54",
-    "selected_match_fg": "#665c54"
+    "fg": "#665c54",
+    "match_fg": "#b57614",
+    "selected_fg": "#504945",
+    "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#3c3836",
     "match_fg": "#b57614",
-    "selected_fg": "transparent",
+    "selected_fg": "#282828",
     "selected_match_fg": "#b57614",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fbf1c7",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d5c4a1",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d5c4a1",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
+    "color_scheme_tint": "#d5c4a1",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-light-soft.sublime-theme
+++ b/base16-gruvbox-light-soft.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d5c4a1",
+    "layer0.tint": "#bdae93",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ebdbb21e",
+    "layer1.tint": "#bdae93",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#bdae93",
+    "layer2.tint": "#d5c4a1",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#bdae93",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5049451e",
+    "layer0.tint": "#bdae931e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#3c3836",
+    "fg": "#504945",
     "match_fg": "#b57614",
-    "selected_fg": "#665c54",
+    "selected_fg": "#504945",
     "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#3c3836",
+    "fg": "#504945",
     "match_fg": "#b57614",
-    "selected_fg": "#665c54",
+    "selected_fg": "#504945",
     "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#3c3836",
-    "match_fg": "#504945",
-    "selected_fg": "#665c54",
-    "selected_match_fg": "#665c54"
+    "fg": "#665c54",
+    "match_fg": "#b57614",
+    "selected_fg": "#504945",
+    "selected_match_fg": "#b57614"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#3c3836",
     "match_fg": "#b57614",
-    "selected_fg": "transparent",
+    "selected_fg": "#282828",
     "selected_match_fg": "#b57614",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f2e5bc",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d5c4a1",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d5c4a1",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
+    "color_scheme_tint": "#d5c4a1",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-material-dark-hard.sublime-theme
+++ b/base16-gruvbox-material-dark-hard.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2a2827",
+    "layer1.tint": "#5a524c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5a524c",
+    "layer2.tint": "#504945",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5a524c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5a524c",
+    "layer0.tint": "#504945",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ddc7a13f",
+    "layer0.tint": "#5a524c3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ebdbb2",
-    "match_fg": "#ddc7a1",
-    "selected_fg": "#bdae93",
-    "selected_match_fg": "#bdae93"
+    "fg": "#bdae93",
+    "match_fg": "#d8a657",
+    "selected_fg": "#ddc7a1",
+    "selected_match_fg": "#d8a657"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5a524c",
+    "layer0.tint": "#504945",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "transparent",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#202020",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5a524c",
+    "layer0.tint": "#504945",
+    "color_scheme_tint": "#504945",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-material-dark-medium.sublime-theme
+++ b/base16-gruvbox-material-dark-medium.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#32302f",
+    "layer1.tint": "#665c54",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#665c54",
+    "layer2.tint": "#504945",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ddc7a13f",
+    "layer0.tint": "#665c543f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ebdbb2",
-    "match_fg": "#ddc7a1",
-    "selected_fg": "#bdae93",
-    "selected_match_fg": "#bdae93"
+    "fg": "#bdae93",
+    "match_fg": "#d8a657",
+    "selected_fg": "#ddc7a1",
+    "selected_match_fg": "#d8a657"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "transparent",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#292828",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#504945",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#504945",
+    "color_scheme_tint": "#504945",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-material-dark-soft.sublime-theme
+++ b/base16-gruvbox-material-dark-soft.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3c3836",
+    "layer1.tint": "#7c6f64",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7c6f64",
+    "layer2.tint": "#5a524c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7c6f64",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7c6f64",
+    "layer0.tint": "#5a524c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ddc7a13f",
+    "layer0.tint": "#7c6f643f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "#bdae93",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ebdbb2",
-    "match_fg": "#ddc7a1",
-    "selected_fg": "#bdae93",
-    "selected_match_fg": "#bdae93"
+    "fg": "#bdae93",
+    "match_fg": "#d8a657",
+    "selected_fg": "#ddc7a1",
+    "selected_match_fg": "#d8a657"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7c6f64",
+    "layer0.tint": "#5a524c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ebdbb2",
     "match_fg": "#d8a657",
-    "selected_fg": "transparent",
+    "selected_fg": "#fbf1c7",
     "selected_match_fg": "#d8a657",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#32302f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5a524c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5a524c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7c6f64",
+    "layer0.tint": "#5a524c",
+    "color_scheme_tint": "#5a524c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-material-light-hard.sublime-theme
+++ b/base16-gruvbox-material-light-hard.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#e0cfa9",
+    "layer0.tint": "#a89984",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#fbf1c71e",
+    "layer1.tint": "#a89984",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#a89984",
+    "layer2.tint": "#e0cfa9",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#a89984",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#a89984",
+    "layer0.tint": "#e0cfa9",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#6547351e",
+    "layer0.tint": "#a899841e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#3c3836",
+    "fg": "#654735",
     "match_fg": "#b47109",
-    "selected_fg": "#c9b99a",
+    "selected_fg": "#654735",
     "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#3c3836",
+    "fg": "#654735",
     "match_fg": "#b47109",
-    "selected_fg": "#c9b99a",
+    "selected_fg": "#654735",
     "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#3c3836",
-    "match_fg": "#654735",
-    "selected_fg": "#c9b99a",
-    "selected_match_fg": "#c9b99a"
+    "fg": "#c9b99a",
+    "match_fg": "#b47109",
+    "selected_fg": "#654735",
+    "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#a89984",
+    "layer0.tint": "#e0cfa9",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#3c3836",
     "match_fg": "#b47109",
-    "selected_fg": "transparent",
+    "selected_fg": "#282828",
     "selected_match_fg": "#b47109",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f9f5d7",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#e0cfa9",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#e0cfa9",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#a89984",
+    "layer0.tint": "#e0cfa9",
+    "color_scheme_tint": "#e0cfa9",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-material-light-medium.sublime-theme
+++ b/base16-gruvbox-material-light-medium.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d5c4a1",
+    "layer0.tint": "#bdae93",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f2e5bc1e",
+    "layer1.tint": "#bdae93",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#bdae93",
+    "layer2.tint": "#d5c4a1",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#bdae93",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#6547351e",
+    "layer0.tint": "#bdae931e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#3c3836",
+    "fg": "#654735",
     "match_fg": "#b47109",
-    "selected_fg": "#665c54",
+    "selected_fg": "#654735",
     "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#3c3836",
+    "fg": "#654735",
     "match_fg": "#b47109",
-    "selected_fg": "#665c54",
+    "selected_fg": "#654735",
     "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#3c3836",
-    "match_fg": "#654735",
-    "selected_fg": "#665c54",
-    "selected_match_fg": "#665c54"
+    "fg": "#665c54",
+    "match_fg": "#b47109",
+    "selected_fg": "#654735",
+    "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#3c3836",
     "match_fg": "#b47109",
-    "selected_fg": "transparent",
+    "selected_fg": "#282828",
     "selected_match_fg": "#b47109",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fbf1c7",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d5c4a1",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d5c4a1",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#bdae93",
+    "layer0.tint": "#d5c4a1",
+    "color_scheme_tint": "#d5c4a1",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-gruvbox-material-light-soft.sublime-theme
+++ b/base16-gruvbox-material-light-soft.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#c9b99a",
+    "layer0.tint": "#a89984",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ebdbb21e",
+    "layer1.tint": "#a89984",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#a89984",
+    "layer2.tint": "#c9b99a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#a89984",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#a89984",
+    "layer0.tint": "#c9b99a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#6547351e",
+    "layer0.tint": "#a899841e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#3c3836",
+    "fg": "#654735",
     "match_fg": "#b47109",
-    "selected_fg": "#665c54",
+    "selected_fg": "#654735",
     "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#3c3836",
+    "fg": "#654735",
     "match_fg": "#b47109",
-    "selected_fg": "#665c54",
+    "selected_fg": "#654735",
     "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#3c3836",
-    "match_fg": "#654735",
-    "selected_fg": "#665c54",
-    "selected_match_fg": "#665c54"
+    "fg": "#665c54",
+    "match_fg": "#b47109",
+    "selected_fg": "#654735",
+    "selected_match_fg": "#b47109"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#a89984",
+    "layer0.tint": "#c9b99a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#3c3836",
     "match_fg": "#b47109",
-    "selected_fg": "transparent",
+    "selected_fg": "#282828",
     "selected_match_fg": "#b47109",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f2e5bc",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#c9b99a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#c9b99a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#a89984",
+    "layer0.tint": "#c9b99a",
+    "color_scheme_tint": "#c9b99a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-hardcore.sublime-theme
+++ b/base16-hardcore.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#303030",
+    "layer1.tint": "#4a4a4a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#4a4a4a",
+    "layer2.tint": "#353535",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#4a4a4a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#4a4a4a",
+    "layer0.tint": "#353535",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cdcdcd3f",
+    "layer0.tint": "#4a4a4a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e5e5e5",
     "match_fg": "#e6db74",
-    "selected_fg": "#707070",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e6db74"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e5e5e5",
     "match_fg": "#e6db74",
-    "selected_fg": "#707070",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e6db74"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e5e5e5",
-    "match_fg": "#cdcdcd",
-    "selected_fg": "#707070",
-    "selected_match_fg": "#707070"
+    "fg": "#707070",
+    "match_fg": "#e6db74",
+    "selected_fg": "#cdcdcd",
+    "selected_match_fg": "#e6db74"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#4a4a4a",
+    "layer0.tint": "#353535",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e5e5e5",
     "match_fg": "#e6db74",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e6db74",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#212121",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#353535",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#353535",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#4a4a4a",
+    "layer0.tint": "#353535",
+    "color_scheme_tint": "#353535",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-harmonic16-dark.sublime-theme
+++ b/base16-harmonic16-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#223b54",
+    "layer1.tint": "#627e99",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#627e99",
+    "layer2.tint": "#405c79",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#627e99",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#627e99",
+    "layer0.tint": "#405c79",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cbd6e23f",
+    "layer0.tint": "#627e993f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e5ebf1",
     "match_fg": "#8bbf56",
-    "selected_fg": "#aabcce",
+    "selected_fg": "#f7f9fb",
     "selected_match_fg": "#8bbf56"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e5ebf1",
     "match_fg": "#8bbf56",
-    "selected_fg": "#aabcce",
+    "selected_fg": "#f7f9fb",
     "selected_match_fg": "#8bbf56"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e5ebf1",
-    "match_fg": "#cbd6e2",
-    "selected_fg": "#aabcce",
-    "selected_match_fg": "#aabcce"
+    "fg": "#aabcce",
+    "match_fg": "#8bbf56",
+    "selected_fg": "#cbd6e2",
+    "selected_match_fg": "#8bbf56"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#627e99",
+    "layer0.tint": "#405c79",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e5ebf1",
     "match_fg": "#8bbf56",
-    "selected_fg": "transparent",
+    "selected_fg": "#f7f9fb",
     "selected_match_fg": "#8bbf56",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0b1c2c",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#405c79",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#405c79",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#627e99",
+    "layer0.tint": "#405c79",
+    "color_scheme_tint": "#405c79",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-harmonic16-light.sublime-theme
+++ b/base16-harmonic16-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#cbd6e2",
+    "layer0.tint": "#aabcce",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e5ebf11e",
+    "layer1.tint": "#aabcce",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#aabcce",
+    "layer2.tint": "#cbd6e2",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#aabcce",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#aabcce",
+    "layer0.tint": "#cbd6e2",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#405c791e",
+    "layer0.tint": "#aabcce1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#223b54",
+    "fg": "#405c79",
     "match_fg": "#8bbf56",
-    "selected_fg": "#627e99",
+    "selected_fg": "#405c79",
     "selected_match_fg": "#8bbf56"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#223b54",
+    "fg": "#405c79",
     "match_fg": "#8bbf56",
-    "selected_fg": "#627e99",
+    "selected_fg": "#405c79",
     "selected_match_fg": "#8bbf56"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#223b54",
-    "match_fg": "#405c79",
-    "selected_fg": "#627e99",
-    "selected_match_fg": "#627e99"
+    "fg": "#627e99",
+    "match_fg": "#8bbf56",
+    "selected_fg": "#405c79",
+    "selected_match_fg": "#8bbf56"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#aabcce",
+    "layer0.tint": "#cbd6e2",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#223b54",
     "match_fg": "#8bbf56",
-    "selected_fg": "transparent",
+    "selected_fg": "#0b1c2c",
     "selected_match_fg": "#8bbf56",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f7f9fb",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#cbd6e2",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#cbd6e2",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#aabcce",
+    "layer0.tint": "#cbd6e2",
+    "color_scheme_tint": "#cbd6e2",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-heetch-light.sublime-theme
+++ b/base16-heetch-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#7b6d8b",
+    "layer0.tint": "#9c92a8",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3925511e",
+    "layer1.tint": "#9c92a8",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9c92a8",
+    "layer2.tint": "#7b6d8b",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9c92a8",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9c92a8",
+    "layer0.tint": "#7b6d8b",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5a496e1e",
+    "layer0.tint": "#9c92a81e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#470546",
+    "fg": "#5a496e",
     "match_fg": "#5ba2b6",
-    "selected_fg": "#ddd6e5",
+    "selected_fg": "#5a496e",
     "selected_match_fg": "#5ba2b6"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#470546",
+    "fg": "#5a496e",
     "match_fg": "#5ba2b6",
-    "selected_fg": "#ddd6e5",
+    "selected_fg": "#5a496e",
     "selected_match_fg": "#5ba2b6"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#470546",
-    "match_fg": "#5a496e",
-    "selected_fg": "#ddd6e5",
-    "selected_match_fg": "#ddd6e5"
+    "fg": "#ddd6e5",
+    "match_fg": "#5ba2b6",
+    "selected_fg": "#5a496e",
+    "selected_match_fg": "#5ba2b6"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9c92a8",
+    "layer0.tint": "#7b6d8b",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#470546",
     "match_fg": "#5ba2b6",
-    "selected_fg": "transparent",
+    "selected_fg": "#190134",
     "selected_match_fg": "#5ba2b6",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#feffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#7b6d8b",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#7b6d8b",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9c92a8",
+    "layer0.tint": "#7b6d8b",
+    "color_scheme_tint": "#7b6d8b",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-heetch.sublime-theme
+++ b/base16-heetch.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#392551",
+    "layer1.tint": "#7b6d8b",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7b6d8b",
+    "layer2.tint": "#5a496e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7b6d8b",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7b6d8b",
+    "layer0.tint": "#5a496e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#bdb6c53f",
+    "layer0.tint": "#7b6d8b3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dedae2",
     "match_fg": "#8f6c97",
-    "selected_fg": "#9c92a8",
+    "selected_fg": "#feffff",
     "selected_match_fg": "#8f6c97"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dedae2",
     "match_fg": "#8f6c97",
-    "selected_fg": "#9c92a8",
+    "selected_fg": "#feffff",
     "selected_match_fg": "#8f6c97"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dedae2",
-    "match_fg": "#bdb6c5",
-    "selected_fg": "#9c92a8",
-    "selected_match_fg": "#9c92a8"
+    "fg": "#9c92a8",
+    "match_fg": "#8f6c97",
+    "selected_fg": "#bdb6c5",
+    "selected_match_fg": "#8f6c97"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7b6d8b",
+    "layer0.tint": "#5a496e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dedae2",
     "match_fg": "#8f6c97",
-    "selected_fg": "transparent",
+    "selected_fg": "#feffff",
     "selected_match_fg": "#8f6c97",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#190134",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5a496e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5a496e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7b6d8b",
+    "layer0.tint": "#5a496e",
+    "color_scheme_tint": "#5a496e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-helios.sublime-theme
+++ b/base16-helios.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#383c3e",
+    "layer1.tint": "#6f7579",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6f7579",
+    "layer2.tint": "#53585b",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6f7579",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6f7579",
+    "layer0.tint": "#53585b",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d5d5d53f",
+    "layer0.tint": "#6f75793f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dddddd",
     "match_fg": "#f19d1a",
-    "selected_fg": "#cdcdcd",
+    "selected_fg": "#e5e5e5",
     "selected_match_fg": "#f19d1a"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dddddd",
     "match_fg": "#f19d1a",
-    "selected_fg": "#cdcdcd",
+    "selected_fg": "#e5e5e5",
     "selected_match_fg": "#f19d1a"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dddddd",
-    "match_fg": "#d5d5d5",
-    "selected_fg": "#cdcdcd",
-    "selected_match_fg": "#cdcdcd"
+    "fg": "#cdcdcd",
+    "match_fg": "#f19d1a",
+    "selected_fg": "#d5d5d5",
+    "selected_match_fg": "#f19d1a"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6f7579",
+    "layer0.tint": "#53585b",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dddddd",
     "match_fg": "#f19d1a",
-    "selected_fg": "transparent",
+    "selected_fg": "#e5e5e5",
     "selected_match_fg": "#f19d1a",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1d2021",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#53585b",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#53585b",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6f7579",
+    "layer0.tint": "#53585b",
+    "color_scheme_tint": "#53585b",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-hopscotch.sublime-theme
+++ b/base16-hopscotch.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#433b42",
+    "layer1.tint": "#797379",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#797379",
+    "layer2.tint": "#5c545b",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#797379",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#797379",
+    "layer0.tint": "#5c545b",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b9b5b83f",
+    "layer0.tint": "#7973793f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d5d3d5",
     "match_fg": "#fdcc59",
-    "selected_fg": "#989498",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fdcc59"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d5d3d5",
     "match_fg": "#fdcc59",
-    "selected_fg": "#989498",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fdcc59"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d5d3d5",
-    "match_fg": "#b9b5b8",
-    "selected_fg": "#989498",
-    "selected_match_fg": "#989498"
+    "fg": "#989498",
+    "match_fg": "#fdcc59",
+    "selected_fg": "#b9b5b8",
+    "selected_match_fg": "#fdcc59"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#797379",
+    "layer0.tint": "#5c545b",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d5d3d5",
     "match_fg": "#fdcc59",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fdcc59",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#322931",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5c545b",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5c545b",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#797379",
+    "layer0.tint": "#5c545b",
+    "color_scheme_tint": "#5c545b",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-horizon-dark.sublime-theme
+++ b/base16-horizon-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#232530",
+    "layer1.tint": "#6f6f70",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6f6f70",
+    "layer2.tint": "#2e303e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6f6f70",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6f6f70",
+    "layer0.tint": "#2e303e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cbced03f",
+    "layer0.tint": "#6f6f703f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dcdfe4",
     "match_fg": "#efb993",
-    "selected_fg": "#9da0a2",
+    "selected_fg": "#e3e6ee",
     "selected_match_fg": "#efb993"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dcdfe4",
     "match_fg": "#efb993",
-    "selected_fg": "#9da0a2",
+    "selected_fg": "#e3e6ee",
     "selected_match_fg": "#efb993"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dcdfe4",
-    "match_fg": "#cbced0",
-    "selected_fg": "#9da0a2",
-    "selected_match_fg": "#9da0a2"
+    "fg": "#9da0a2",
+    "match_fg": "#efb993",
+    "selected_fg": "#cbced0",
+    "selected_match_fg": "#efb993"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6f6f70",
+    "layer0.tint": "#2e303e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dcdfe4",
     "match_fg": "#efb993",
-    "selected_fg": "transparent",
+    "selected_fg": "#e3e6ee",
     "selected_match_fg": "#efb993",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1c1e26",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2e303e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2e303e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6f6f70",
+    "layer0.tint": "#2e303e",
+    "color_scheme_tint": "#2e303e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-horizon-light.sublime-theme
+++ b/base16-horizon-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#f9cbbe",
+    "layer0.tint": "#bdb3b1",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#fadad11e",
+    "layer1.tint": "#bdb3b1",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#bdb3b1",
+    "layer2.tint": "#f9cbbe",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#bdb3b1",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#bdb3b1",
+    "layer0.tint": "#f9cbbe",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#403c3d1e",
+    "layer0.tint": "#bdb3b11e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#302c2d",
+    "fg": "#403c3d",
     "match_fg": "#fbe0d9",
-    "selected_fg": "#948c8a",
+    "selected_fg": "#403c3d",
     "selected_match_fg": "#fbe0d9"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#302c2d",
+    "fg": "#403c3d",
     "match_fg": "#fbe0d9",
-    "selected_fg": "#948c8a",
+    "selected_fg": "#403c3d",
     "selected_match_fg": "#fbe0d9"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#302c2d",
-    "match_fg": "#403c3d",
-    "selected_fg": "#948c8a",
-    "selected_match_fg": "#948c8a"
+    "fg": "#948c8a",
+    "match_fg": "#fbe0d9",
+    "selected_fg": "#403c3d",
+    "selected_match_fg": "#fbe0d9"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#bdb3b1",
+    "layer0.tint": "#f9cbbe",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#302c2d",
     "match_fg": "#fbe0d9",
-    "selected_fg": "transparent",
+    "selected_fg": "#201c1d",
     "selected_match_fg": "#fbe0d9",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fdf0ed",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#f9cbbe",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#f9cbbe",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#bdb3b1",
+    "layer0.tint": "#f9cbbe",
+    "color_scheme_tint": "#f9cbbe",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-horizon-terminal-dark.sublime-theme
+++ b/base16-horizon-terminal-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#232530",
+    "layer1.tint": "#6f6f70",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6f6f70",
+    "layer2.tint": "#2e303e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6f6f70",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6f6f70",
+    "layer0.tint": "#2e303e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cbced03f",
+    "layer0.tint": "#6f6f703f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dcdfe4",
     "match_fg": "#fac29a",
-    "selected_fg": "#9da0a2",
+    "selected_fg": "#e3e6ee",
     "selected_match_fg": "#fac29a"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dcdfe4",
     "match_fg": "#fac29a",
-    "selected_fg": "#9da0a2",
+    "selected_fg": "#e3e6ee",
     "selected_match_fg": "#fac29a"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dcdfe4",
-    "match_fg": "#cbced0",
-    "selected_fg": "#9da0a2",
-    "selected_match_fg": "#9da0a2"
+    "fg": "#9da0a2",
+    "match_fg": "#fac29a",
+    "selected_fg": "#cbced0",
+    "selected_match_fg": "#fac29a"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6f6f70",
+    "layer0.tint": "#2e303e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dcdfe4",
     "match_fg": "#fac29a",
-    "selected_fg": "transparent",
+    "selected_fg": "#e3e6ee",
     "selected_match_fg": "#fac29a",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1c1e26",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2e303e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2e303e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6f6f70",
+    "layer0.tint": "#2e303e",
+    "color_scheme_tint": "#2e303e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-horizon-terminal-light.sublime-theme
+++ b/base16-horizon-terminal-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#f9cbbe",
+    "layer0.tint": "#bdb3b1",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#fadad11e",
+    "layer1.tint": "#bdb3b1",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#bdb3b1",
+    "layer2.tint": "#f9cbbe",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#bdb3b1",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#bdb3b1",
+    "layer0.tint": "#f9cbbe",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#403c3d1e",
+    "layer0.tint": "#bdb3b11e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#302c2d",
+    "fg": "#403c3d",
     "match_fg": "#fadad1",
-    "selected_fg": "#948c8a",
+    "selected_fg": "#403c3d",
     "selected_match_fg": "#fadad1"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#302c2d",
+    "fg": "#403c3d",
     "match_fg": "#fadad1",
-    "selected_fg": "#948c8a",
+    "selected_fg": "#403c3d",
     "selected_match_fg": "#fadad1"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#302c2d",
-    "match_fg": "#403c3d",
-    "selected_fg": "#948c8a",
-    "selected_match_fg": "#948c8a"
+    "fg": "#948c8a",
+    "match_fg": "#fadad1",
+    "selected_fg": "#403c3d",
+    "selected_match_fg": "#fadad1"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#bdb3b1",
+    "layer0.tint": "#f9cbbe",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#302c2d",
     "match_fg": "#fadad1",
-    "selected_fg": "transparent",
+    "selected_fg": "#201c1d",
     "selected_match_fg": "#fadad1",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fdf0ed",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#f9cbbe",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#f9cbbe",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#bdb3b1",
+    "layer0.tint": "#f9cbbe",
+    "color_scheme_tint": "#f9cbbe",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-humanoid-dark.sublime-theme
+++ b/base16-humanoid-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#333b3d",
+    "layer1.tint": "#60615d",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#60615d",
+    "layer2.tint": "#484e54",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#60615d",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#60615d",
+    "layer0.tint": "#484e54",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#f8f8f23f",
+    "layer0.tint": "#60615d3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#fcfcf6",
     "match_fg": "#ffb627",
-    "selected_fg": "#c0c0bd",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#ffb627"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#fcfcf6",
     "match_fg": "#ffb627",
-    "selected_fg": "#c0c0bd",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#ffb627"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#fcfcf6",
-    "match_fg": "#f8f8f2",
-    "selected_fg": "#c0c0bd",
-    "selected_match_fg": "#c0c0bd"
+    "fg": "#c0c0bd",
+    "match_fg": "#ffb627",
+    "selected_fg": "#f8f8f2",
+    "selected_match_fg": "#ffb627"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#60615d",
+    "layer0.tint": "#484e54",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#fcfcf6",
     "match_fg": "#ffb627",
-    "selected_fg": "transparent",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#ffb627",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#232629",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#484e54",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#484e54",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#60615d",
+    "layer0.tint": "#484e54",
+    "color_scheme_tint": "#484e54",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-humanoid-light.sublime-theme
+++ b/base16-humanoid-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#deded8",
+    "layer0.tint": "#c0c0bd",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#efefe91e",
+    "layer1.tint": "#c0c0bd",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#c0c0bd",
+    "layer2.tint": "#deded8",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#c0c0bd",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#c0c0bd",
+    "layer0.tint": "#deded8",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#2326291e",
+    "layer0.tint": "#c0c0bd1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#2f3337",
+    "fg": "#232629",
     "match_fg": "#ffb627",
-    "selected_fg": "#60615d",
+    "selected_fg": "#232629",
     "selected_match_fg": "#ffb627"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#2f3337",
+    "fg": "#232629",
     "match_fg": "#ffb627",
-    "selected_fg": "#60615d",
+    "selected_fg": "#232629",
     "selected_match_fg": "#ffb627"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#2f3337",
-    "match_fg": "#232629",
-    "selected_fg": "#60615d",
-    "selected_match_fg": "#60615d"
+    "fg": "#60615d",
+    "match_fg": "#ffb627",
+    "selected_fg": "#232629",
+    "selected_match_fg": "#ffb627"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#c0c0bd",
+    "layer0.tint": "#deded8",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#2f3337",
     "match_fg": "#ffb627",
-    "selected_fg": "transparent",
+    "selected_fg": "#070708",
     "selected_match_fg": "#ffb627",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f8f8f2",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#deded8",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#deded8",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#c0c0bd",
+    "layer0.tint": "#deded8",
+    "color_scheme_tint": "#deded8",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-ia-dark.sublime-theme
+++ b/base16-ia-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#222222",
+    "layer1.tint": "#767676",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#767676",
+    "layer2.tint": "#1d414d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#767676",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#767676",
+    "layer0.tint": "#1d414d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cccccc3f",
+    "layer0.tint": "#7676763f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e8e8",
     "match_fg": "#b99353",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#b99353"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e8e8",
     "match_fg": "#b99353",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#b99353"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e8e8",
-    "match_fg": "#cccccc",
-    "selected_fg": "#b8b8b8",
-    "selected_match_fg": "#b8b8b8"
+    "fg": "#b8b8b8",
+    "match_fg": "#b99353",
+    "selected_fg": "#cccccc",
+    "selected_match_fg": "#b99353"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#767676",
+    "layer0.tint": "#1d414d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e8e8",
     "match_fg": "#b99353",
-    "selected_fg": "transparent",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#b99353",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1a1a1a",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#1d414d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#1d414d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#767676",
+    "layer0.tint": "#1d414d",
+    "color_scheme_tint": "#1d414d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-ia-light.sublime-theme
+++ b/base16-ia-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#bde5f2",
+    "layer0.tint": "#898989",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#dedede1e",
+    "layer1.tint": "#898989",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#898989",
+    "layer2.tint": "#bde5f2",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#898989",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#898989",
+    "layer0.tint": "#bde5f2",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#1818181e",
+    "layer0.tint": "#8989891e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#e8e8e8",
+    "fg": "#181818",
     "match_fg": "#c48218",
-    "selected_fg": "#767676",
+    "selected_fg": "#181818",
     "selected_match_fg": "#c48218"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#e8e8e8",
+    "fg": "#181818",
     "match_fg": "#c48218",
-    "selected_fg": "#767676",
+    "selected_fg": "#181818",
     "selected_match_fg": "#c48218"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e8e8",
-    "match_fg": "#181818",
-    "selected_fg": "#767676",
-    "selected_match_fg": "#767676"
+    "fg": "#767676",
+    "match_fg": "#c48218",
+    "selected_fg": "#181818",
+    "selected_match_fg": "#c48218"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#898989",
+    "layer0.tint": "#bde5f2",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e8e8",
     "match_fg": "#c48218",
-    "selected_fg": "transparent",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#c48218",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f6f6f6",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#bde5f2",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#bde5f2",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#898989",
+    "layer0.tint": "#bde5f2",
+    "color_scheme_tint": "#bde5f2",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-icy.sublime-theme
+++ b/base16-icy.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#041f23",
+    "layer0.tint": "#052e34",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#0316191e",
+    "layer1.tint": "#052e34",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#052e34",
+    "layer2.tint": "#041f23",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#052e34",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#052e34",
+    "layer0.tint": "#041f23",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#095b671e",
+    "layer0.tint": "#052e341e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#0c7c8c",
+    "fg": "#095b67",
     "match_fg": "#80deea",
-    "selected_fg": "#064048",
+    "selected_fg": "#095b67",
     "selected_match_fg": "#80deea"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#0c7c8c",
+    "fg": "#095b67",
     "match_fg": "#80deea",
-    "selected_fg": "#064048",
+    "selected_fg": "#095b67",
     "selected_match_fg": "#80deea"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#0c7c8c",
-    "match_fg": "#095b67",
-    "selected_fg": "#064048",
-    "selected_match_fg": "#064048"
+    "fg": "#064048",
+    "match_fg": "#80deea",
+    "selected_fg": "#095b67",
+    "selected_match_fg": "#80deea"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#052e34",
+    "layer0.tint": "#041f23",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#0c7c8c",
     "match_fg": "#80deea",
-    "selected_fg": "transparent",
+    "selected_fg": "#109cb0",
     "selected_match_fg": "#80deea",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#021012",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#041f23",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#041f23",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#052e34",
+    "layer0.tint": "#041f23",
+    "color_scheme_tint": "#041f23",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-irblack.sublime-theme
+++ b/base16-irblack.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#242422",
+    "layer1.tint": "#6c6c66",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6c6c66",
+    "layer2.tint": "#484844",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6c6c66",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6c6c66",
+    "layer0.tint": "#484844",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b5b3aa3f",
+    "layer0.tint": "#6c6c663f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d9d7cc",
     "match_fg": "#ffffb6",
-    "selected_fg": "#918f88",
+    "selected_fg": "#fdfbee",
     "selected_match_fg": "#ffffb6"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d9d7cc",
     "match_fg": "#ffffb6",
-    "selected_fg": "#918f88",
+    "selected_fg": "#fdfbee",
     "selected_match_fg": "#ffffb6"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d9d7cc",
-    "match_fg": "#b5b3aa",
-    "selected_fg": "#918f88",
-    "selected_match_fg": "#918f88"
+    "fg": "#918f88",
+    "match_fg": "#ffffb6",
+    "selected_fg": "#b5b3aa",
+    "selected_match_fg": "#ffffb6"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6c6c66",
+    "layer0.tint": "#484844",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d9d7cc",
     "match_fg": "#ffffb6",
-    "selected_fg": "transparent",
+    "selected_fg": "#fdfbee",
     "selected_match_fg": "#ffffb6",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#484844",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#484844",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6c6c66",
+    "layer0.tint": "#484844",
+    "color_scheme_tint": "#484844",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-isotope.sublime-theme
+++ b/base16-isotope.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#404040",
+    "layer1.tint": "#808080",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#808080",
+    "layer2.tint": "#606060",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#808080",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#606060",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0d0d03f",
+    "layer0.tint": "#8080803f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#ff0099",
-    "selected_fg": "#c0c0c0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff0099"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#ff0099",
-    "selected_fg": "#c0c0c0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff0099"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#d0d0d0",
-    "selected_fg": "#c0c0c0",
-    "selected_match_fg": "#c0c0c0"
+    "fg": "#c0c0c0",
+    "match_fg": "#ff0099",
+    "selected_fg": "#d0d0d0",
+    "selected_match_fg": "#ff0099"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#808080",
+    "layer0.tint": "#606060",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#ff0099",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff0099",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#606060",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#606060",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#606060",
+    "color_scheme_tint": "#606060",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-jabuti.sublime-theme
+++ b/base16-jabuti.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#343545",
+    "layer1.tint": "#45475d",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#45475d",
+    "layer2.tint": "#3c3e51",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#45475d",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#45475d",
+    "layer0.tint": "#3c3e51",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c0cbe33f",
+    "layer0.tint": "#45475d3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d9e0ee",
     "match_fg": "#e1c697",
-    "selected_fg": "#50526b",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e1c697"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d9e0ee",
     "match_fg": "#e1c697",
-    "selected_fg": "#50526b",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e1c697"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d9e0ee",
-    "match_fg": "#c0cbe3",
-    "selected_fg": "#50526b",
-    "selected_match_fg": "#50526b"
+    "fg": "#50526b",
+    "match_fg": "#e1c697",
+    "selected_fg": "#c0cbe3",
+    "selected_match_fg": "#e1c697"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#45475d",
+    "layer0.tint": "#3c3e51",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d9e0ee",
     "match_fg": "#e1c697",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e1c697",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#292a37",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3c3e51",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3c3e51",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#45475d",
+    "layer0.tint": "#3c3e51",
+    "color_scheme_tint": "#3c3e51",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-kanagawa.sublime-theme
+++ b/base16-kanagawa.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#16161d",
+    "layer1.tint": "#54546d",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#54546d",
+    "layer2.tint": "#223249",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#54546d",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#54546d",
+    "layer0.tint": "#223249",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#dcd7ba3f",
+    "layer0.tint": "#54546d3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c8c093",
     "match_fg": "#c0a36e",
-    "selected_fg": "#727169",
+    "selected_fg": "#717c7c",
     "selected_match_fg": "#c0a36e"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c8c093",
     "match_fg": "#c0a36e",
-    "selected_fg": "#727169",
+    "selected_fg": "#717c7c",
     "selected_match_fg": "#c0a36e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c8c093",
-    "match_fg": "#dcd7ba",
-    "selected_fg": "#727169",
-    "selected_match_fg": "#727169"
+    "fg": "#727169",
+    "match_fg": "#c0a36e",
+    "selected_fg": "#dcd7ba",
+    "selected_match_fg": "#c0a36e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#54546d",
+    "layer0.tint": "#223249",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c8c093",
     "match_fg": "#c0a36e",
-    "selected_fg": "transparent",
+    "selected_fg": "#717c7c",
     "selected_match_fg": "#c0a36e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1f1f28",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#223249",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#223249",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#54546d",
+    "layer0.tint": "#223249",
+    "color_scheme_tint": "#223249",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-katy.sublime-theme
+++ b/base16-katy.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#444267",
+    "layer1.tint": "#676e95",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#676e95",
+    "layer2.tint": "#5c598b",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#676e95",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#676e95",
+    "layer0.tint": "#5c598b",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#959dcb3f",
+    "layer0.tint": "#676e953f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#959dcb",
     "match_fg": "#e0a557",
-    "selected_fg": "#8796b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e0a557"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#959dcb",
     "match_fg": "#e0a557",
-    "selected_fg": "#8796b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e0a557"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#959dcb",
-    "match_fg": "#959dcb",
-    "selected_fg": "#8796b0",
-    "selected_match_fg": "#8796b0"
+    "fg": "#8796b0",
+    "match_fg": "#e0a557",
+    "selected_fg": "#959dcb",
+    "selected_match_fg": "#e0a557"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#676e95",
+    "layer0.tint": "#5c598b",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#959dcb",
     "match_fg": "#e0a557",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e0a557",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#292d3e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5c598b",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5c598b",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#676e95",
+    "layer0.tint": "#5c598b",
+    "color_scheme_tint": "#5c598b",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-kimber.sublime-theme
+++ b/base16-kimber.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#313131",
+    "layer1.tint": "#644646",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#644646",
+    "layer2.tint": "#555d55",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#644646",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#644646",
+    "layer0.tint": "#555d55",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#dedee73f",
+    "layer0.tint": "#6446463f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c3c3b4",
     "match_fg": "#d8b56d",
-    "selected_fg": "#5a5a5a",
+    "selected_fg": "#ffffe6",
     "selected_match_fg": "#d8b56d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c3c3b4",
     "match_fg": "#d8b56d",
-    "selected_fg": "#5a5a5a",
+    "selected_fg": "#ffffe6",
     "selected_match_fg": "#d8b56d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c3c3b4",
-    "match_fg": "#dedee7",
-    "selected_fg": "#5a5a5a",
-    "selected_match_fg": "#5a5a5a"
+    "fg": "#5a5a5a",
+    "match_fg": "#d8b56d",
+    "selected_fg": "#dedee7",
+    "selected_match_fg": "#d8b56d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#644646",
+    "layer0.tint": "#555d55",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c3c3b4",
     "match_fg": "#d8b56d",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffe6",
     "selected_match_fg": "#d8b56d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#555d55",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#555d55",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#644646",
+    "layer0.tint": "#555d55",
+    "color_scheme_tint": "#555d55",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-lime.sublime-theme
+++ b/base16-lime.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#202030",
+    "layer1.tint": "#313140",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#313140",
+    "layer2.tint": "#2a2a3f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#313140",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#313140",
+    "layer0.tint": "#2a2a3f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8181753f",
+    "layer0.tint": "#3131403f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#fff2d1",
     "match_fg": "#ffd15e",
-    "selected_fg": "#515155",
+    "selected_fg": "#fff8e1",
     "selected_match_fg": "#ffd15e"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#fff2d1",
     "match_fg": "#ffd15e",
-    "selected_fg": "#515155",
+    "selected_fg": "#fff8e1",
     "selected_match_fg": "#ffd15e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#fff2d1",
-    "match_fg": "#818175",
-    "selected_fg": "#515155",
-    "selected_match_fg": "#515155"
+    "fg": "#515155",
+    "match_fg": "#ffd15e",
+    "selected_fg": "#818175",
+    "selected_match_fg": "#ffd15e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#313140",
+    "layer0.tint": "#2a2a3f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#fff2d1",
     "match_fg": "#ffd15e",
-    "selected_fg": "transparent",
+    "selected_fg": "#fff8e1",
     "selected_match_fg": "#ffd15e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1a1a2f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2a2a3f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2a2a3f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#313140",
+    "layer0.tint": "#2a2a3f",
+    "color_scheme_tint": "#2a2a3f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-macintosh.sublime-theme
+++ b/base16-macintosh.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#404040",
+    "layer1.tint": "#808080",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#808080",
+    "layer2.tint": "#404040",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#808080",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#404040",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c0c0c03f",
+    "layer0.tint": "#8080803f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c0c0c0",
     "match_fg": "#fbf305",
-    "selected_fg": "#808080",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbf305"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c0c0c0",
     "match_fg": "#fbf305",
-    "selected_fg": "#808080",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbf305"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c0c0c0",
-    "match_fg": "#c0c0c0",
-    "selected_fg": "#808080",
-    "selected_match_fg": "#808080"
+    "fg": "#808080",
+    "match_fg": "#fbf305",
+    "selected_fg": "#c0c0c0",
+    "selected_match_fg": "#fbf305"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#808080",
+    "layer0.tint": "#404040",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c0c0c0",
     "match_fg": "#fbf305",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbf305",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#404040",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#404040",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#404040",
+    "color_scheme_tint": "#404040",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-marrakesh.sublime-theme
+++ b/base16-marrakesh.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#302e00",
+    "layer1.tint": "#6c6823",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6c6823",
+    "layer2.tint": "#5f5b17",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6c6823",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6c6823",
+    "layer0.tint": "#5f5b17",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#948e483f",
+    "layer0.tint": "#6c68233f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ccc37a",
     "match_fg": "#a88339",
-    "selected_fg": "#86813b",
+    "selected_fg": "#faf0a5",
     "selected_match_fg": "#a88339"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ccc37a",
     "match_fg": "#a88339",
-    "selected_fg": "#86813b",
+    "selected_fg": "#faf0a5",
     "selected_match_fg": "#a88339"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ccc37a",
-    "match_fg": "#948e48",
-    "selected_fg": "#86813b",
-    "selected_match_fg": "#86813b"
+    "fg": "#86813b",
+    "match_fg": "#a88339",
+    "selected_fg": "#948e48",
+    "selected_match_fg": "#a88339"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6c6823",
+    "layer0.tint": "#5f5b17",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ccc37a",
     "match_fg": "#a88339",
-    "selected_fg": "transparent",
+    "selected_fg": "#faf0a5",
     "selected_match_fg": "#a88339",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#201602",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5f5b17",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5f5b17",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6c6823",
+    "layer0.tint": "#5f5b17",
+    "color_scheme_tint": "#5f5b17",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-materia.sublime-theme
+++ b/base16-materia.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2c393f",
+    "layer1.tint": "#707880",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#707880",
+    "layer2.tint": "#37474f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#707880",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#707880",
+    "layer0.tint": "#37474f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cdd3de3f",
+    "layer0.tint": "#7078803f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d5dbe5",
     "match_fg": "#ffcc00",
-    "selected_fg": "#c9ccd3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcc00"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d5dbe5",
     "match_fg": "#ffcc00",
-    "selected_fg": "#c9ccd3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcc00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d5dbe5",
-    "match_fg": "#cdd3de",
-    "selected_fg": "#c9ccd3",
-    "selected_match_fg": "#c9ccd3"
+    "fg": "#c9ccd3",
+    "match_fg": "#ffcc00",
+    "selected_fg": "#cdd3de",
+    "selected_match_fg": "#ffcc00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#707880",
+    "layer0.tint": "#37474f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d5dbe5",
     "match_fg": "#ffcc00",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcc00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#263238",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#37474f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#37474f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#707880",
+    "layer0.tint": "#37474f",
+    "color_scheme_tint": "#37474f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-material-darker.sublime-theme
+++ b/base16-material-darker.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#303030",
+    "layer1.tint": "#4a4a4a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#4a4a4a",
+    "layer2.tint": "#353535",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#4a4a4a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#4a4a4a",
+    "layer0.tint": "#353535",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#eeffff3f",
+    "layer0.tint": "#4a4a4a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#eeffff",
     "match_fg": "#ffcb6b",
-    "selected_fg": "#b2ccd6",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#eeffff",
     "match_fg": "#ffcb6b",
-    "selected_fg": "#b2ccd6",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#eeffff",
-    "match_fg": "#eeffff",
-    "selected_fg": "#b2ccd6",
-    "selected_match_fg": "#b2ccd6"
+    "fg": "#b2ccd6",
+    "match_fg": "#ffcb6b",
+    "selected_fg": "#eeffff",
+    "selected_match_fg": "#ffcb6b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#4a4a4a",
+    "layer0.tint": "#353535",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eeffff",
     "match_fg": "#ffcb6b",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#212121",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#353535",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#353535",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#4a4a4a",
+    "layer0.tint": "#353535",
+    "color_scheme_tint": "#353535",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-material-lighter.sublime-theme
+++ b/base16-material-lighter.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#cceae7",
+    "layer0.tint": "#ccd7da",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e7eaec1e",
+    "layer1.tint": "#ccd7da",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#ccd7da",
+    "layer2.tint": "#cceae7",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#ccd7da",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#ccd7da",
+    "layer0.tint": "#cceae7",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#80cbc41e",
+    "layer0.tint": "#ccd7da1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#80cbc4",
     "match_fg": "#ffb62c",
-    "selected_fg": "#8796b0",
+    "selected_fg": "#80cbc4",
     "selected_match_fg": "#ffb62c"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#80cbc4",
     "match_fg": "#ffb62c",
-    "selected_fg": "#8796b0",
+    "selected_fg": "#80cbc4",
     "selected_match_fg": "#ffb62c"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#80cbc4",
-    "match_fg": "#80cbc4",
-    "selected_fg": "#8796b0",
-    "selected_match_fg": "#8796b0"
+    "fg": "#8796b0",
+    "match_fg": "#ffb62c",
+    "selected_fg": "#80cbc4",
+    "selected_match_fg": "#ffb62c"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#ccd7da",
+    "layer0.tint": "#cceae7",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#80cbc4",
     "match_fg": "#ffb62c",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffb62c",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fafafa",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#cceae7",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#cceae7",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#ccd7da",
+    "layer0.tint": "#cceae7",
+    "color_scheme_tint": "#cceae7",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-material-palenight.sublime-theme
+++ b/base16-material-palenight.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#444267",
+    "layer1.tint": "#676e95",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#676e95",
+    "layer2.tint": "#32374d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#676e95",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#676e95",
+    "layer0.tint": "#32374d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#959dcb3f",
+    "layer0.tint": "#676e953f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#959dcb",
     "match_fg": "#ffcb6b",
-    "selected_fg": "#8796b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#959dcb",
     "match_fg": "#ffcb6b",
-    "selected_fg": "#8796b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#959dcb",
-    "match_fg": "#959dcb",
-    "selected_fg": "#8796b0",
-    "selected_match_fg": "#8796b0"
+    "fg": "#8796b0",
+    "match_fg": "#ffcb6b",
+    "selected_fg": "#959dcb",
+    "selected_match_fg": "#ffcb6b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#676e95",
+    "layer0.tint": "#32374d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#959dcb",
     "match_fg": "#ffcb6b",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#292d3e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#32374d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#32374d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#676e95",
+    "layer0.tint": "#32374d",
+    "color_scheme_tint": "#32374d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-material-vivid.sublime-theme
+++ b/base16-material-vivid.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#27292c",
+    "layer1.tint": "#44464d",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#44464d",
+    "layer2.tint": "#323639",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#44464d",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#44464d",
+    "layer0.tint": "#323639",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#80868b3f",
+    "layer0.tint": "#44464d3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#9e9e9e",
     "match_fg": "#ffeb3b",
-    "selected_fg": "#676c71",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffeb3b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#9e9e9e",
     "match_fg": "#ffeb3b",
-    "selected_fg": "#676c71",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffeb3b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#9e9e9e",
-    "match_fg": "#80868b",
-    "selected_fg": "#676c71",
-    "selected_match_fg": "#676c71"
+    "fg": "#676c71",
+    "match_fg": "#ffeb3b",
+    "selected_fg": "#80868b",
+    "selected_match_fg": "#ffeb3b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#44464d",
+    "layer0.tint": "#323639",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#9e9e9e",
     "match_fg": "#ffeb3b",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffeb3b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#202124",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#323639",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#323639",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#44464d",
+    "layer0.tint": "#323639",
+    "color_scheme_tint": "#323639",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-material.sublime-theme
+++ b/base16-material.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2e3c43",
+    "layer1.tint": "#546e7a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#546e7a",
+    "layer2.tint": "#314549",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#546e7a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#546e7a",
+    "layer0.tint": "#314549",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#eeffff3f",
+    "layer0.tint": "#546e7a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#eeffff",
     "match_fg": "#ffcb6b",
-    "selected_fg": "#b2ccd6",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#eeffff",
     "match_fg": "#ffcb6b",
-    "selected_fg": "#b2ccd6",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#eeffff",
-    "match_fg": "#eeffff",
-    "selected_fg": "#b2ccd6",
-    "selected_match_fg": "#b2ccd6"
+    "fg": "#b2ccd6",
+    "match_fg": "#ffcb6b",
+    "selected_fg": "#eeffff",
+    "selected_match_fg": "#ffcb6b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#546e7a",
+    "layer0.tint": "#314549",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eeffff",
     "match_fg": "#ffcb6b",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcb6b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#263238",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#314549",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#314549",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#546e7a",
+    "layer0.tint": "#314549",
+    "color_scheme_tint": "#314549",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-measured-dark.sublime-theme
+++ b/base16-measured-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#003a38",
+    "layer1.tint": "#ababab",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#ababab",
+    "layer2.tint": "#005453",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#ababab",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#ababab",
+    "layer0.tint": "#005453",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#dcdcdc3f",
+    "layer0.tint": "#ababab3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#efefef",
     "match_fg": "#bfac4e",
-    "selected_fg": "#c3c3c3",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#bfac4e"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#efefef",
     "match_fg": "#bfac4e",
-    "selected_fg": "#c3c3c3",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#bfac4e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#efefef",
-    "match_fg": "#dcdcdc",
-    "selected_fg": "#c3c3c3",
-    "selected_match_fg": "#c3c3c3"
+    "fg": "#c3c3c3",
+    "match_fg": "#bfac4e",
+    "selected_fg": "#dcdcdc",
+    "selected_match_fg": "#bfac4e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#ababab",
+    "layer0.tint": "#005453",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#efefef",
     "match_fg": "#bfac4e",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#bfac4e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#00211f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#005453",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#005453",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#ababab",
+    "layer0.tint": "#005453",
+    "color_scheme_tint": "#005453",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-measured-light.sublime-theme
+++ b/base16-measured-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#ffeada",
+    "layer0.tint": "#5a5a5a",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f9f5f11e",
+    "layer1.tint": "#5a5a5a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5a5a5a",
+    "layer2.tint": "#ffeada",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5a5a5a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5a5a5a",
+    "layer0.tint": "#ffeada",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#2929291e",
+    "layer0.tint": "#5a5a5a1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#181818",
+    "fg": "#292929",
     "match_fg": "#645a00",
-    "selected_fg": "#404040",
+    "selected_fg": "#292929",
     "selected_match_fg": "#645a00"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#181818",
+    "fg": "#292929",
     "match_fg": "#645a00",
-    "selected_fg": "#404040",
+    "selected_fg": "#292929",
     "selected_match_fg": "#645a00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#181818",
-    "match_fg": "#292929",
-    "selected_fg": "#404040",
-    "selected_match_fg": "#404040"
+    "fg": "#404040",
+    "match_fg": "#645a00",
+    "selected_fg": "#292929",
+    "selected_match_fg": "#645a00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5a5a5a",
+    "layer0.tint": "#ffeada",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#181818",
     "match_fg": "#645a00",
-    "selected_fg": "transparent",
+    "selected_fg": "#000000",
     "selected_match_fg": "#645a00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fdf9f5",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#ffeada",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#ffeada",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5a5a5a",
+    "layer0.tint": "#ffeada",
+    "color_scheme_tint": "#ffeada",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-mellow-purple.sublime-theme
+++ b/base16-mellow-purple.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1a092d",
+    "layer1.tint": "#320f55",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#320f55",
+    "layer2.tint": "#331354",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#320f55",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#320f55",
+    "layer0.tint": "#331354",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ffeeff3f",
+    "layer0.tint": "#320f553f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffeeff",
     "match_fg": "#955ae7",
-    "selected_fg": "#873582",
+    "selected_fg": "#f8c0ff",
     "selected_match_fg": "#955ae7"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffeeff",
     "match_fg": "#955ae7",
-    "selected_fg": "#873582",
+    "selected_fg": "#f8c0ff",
     "selected_match_fg": "#955ae7"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffeeff",
-    "match_fg": "#ffeeff",
-    "selected_fg": "#873582",
-    "selected_match_fg": "#873582"
+    "fg": "#873582",
+    "match_fg": "#955ae7",
+    "selected_fg": "#ffeeff",
+    "selected_match_fg": "#955ae7"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#320f55",
+    "layer0.tint": "#331354",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffeeff",
     "match_fg": "#955ae7",
-    "selected_fg": "transparent",
+    "selected_fg": "#f8c0ff",
     "selected_match_fg": "#955ae7",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1e0528",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#331354",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#331354",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#320f55",
+    "layer0.tint": "#331354",
+    "color_scheme_tint": "#331354",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-mexico-light.sublime-theme
+++ b/base16-mexico-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d8d8d8",
+    "layer0.tint": "#b8b8b8",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e8e8e81e",
+    "layer1.tint": "#b8b8b8",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b8b8b8",
+    "layer2.tint": "#d8d8d8",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b8b8b8",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3838381e",
+    "layer0.tint": "#b8b8b81e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#282828",
+    "fg": "#383838",
     "match_fg": "#f79a0e",
-    "selected_fg": "#585858",
+    "selected_fg": "#383838",
     "selected_match_fg": "#f79a0e"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#282828",
+    "fg": "#383838",
     "match_fg": "#f79a0e",
-    "selected_fg": "#585858",
+    "selected_fg": "#383838",
     "selected_match_fg": "#f79a0e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#282828",
-    "match_fg": "#383838",
-    "selected_fg": "#585858",
-    "selected_match_fg": "#585858"
+    "fg": "#585858",
+    "match_fg": "#f79a0e",
+    "selected_fg": "#383838",
+    "selected_match_fg": "#f79a0e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#282828",
     "match_fg": "#f79a0e",
-    "selected_fg": "transparent",
+    "selected_fg": "#181818",
     "selected_match_fg": "#f79a0e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f8f8f8",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d8d8d8",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d8d8d8",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
+    "color_scheme_tint": "#d8d8d8",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-mocha.sublime-theme
+++ b/base16-mocha.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#534636",
+    "layer1.tint": "#7e705a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7e705a",
+    "layer2.tint": "#645240",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7e705a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7e705a",
+    "layer0.tint": "#645240",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0c8c63f",
+    "layer0.tint": "#7e705a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e9e1dd",
     "match_fg": "#f4bc87",
-    "selected_fg": "#b8afad",
+    "selected_fg": "#f5eeeb",
     "selected_match_fg": "#f4bc87"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e9e1dd",
     "match_fg": "#f4bc87",
-    "selected_fg": "#b8afad",
+    "selected_fg": "#f5eeeb",
     "selected_match_fg": "#f4bc87"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e9e1dd",
-    "match_fg": "#d0c8c6",
-    "selected_fg": "#b8afad",
-    "selected_match_fg": "#b8afad"
+    "fg": "#b8afad",
+    "match_fg": "#f4bc87",
+    "selected_fg": "#d0c8c6",
+    "selected_match_fg": "#f4bc87"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7e705a",
+    "layer0.tint": "#645240",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e9e1dd",
     "match_fg": "#f4bc87",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5eeeb",
     "selected_match_fg": "#f4bc87",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#3b3228",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#645240",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#645240",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7e705a",
+    "layer0.tint": "#645240",
+    "color_scheme_tint": "#645240",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-monokai.sublime-theme
+++ b/base16-monokai.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#383830",
+    "layer1.tint": "#75715e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#75715e",
+    "layer2.tint": "#49483e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#75715e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#75715e",
+    "layer0.tint": "#49483e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#f8f8f23f",
+    "layer0.tint": "#75715e3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f5f4f1",
     "match_fg": "#f4bf75",
-    "selected_fg": "#a59f85",
+    "selected_fg": "#f9f8f5",
     "selected_match_fg": "#f4bf75"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f5f4f1",
     "match_fg": "#f4bf75",
-    "selected_fg": "#a59f85",
+    "selected_fg": "#f9f8f5",
     "selected_match_fg": "#f4bf75"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f5f4f1",
-    "match_fg": "#f8f8f2",
-    "selected_fg": "#a59f85",
-    "selected_match_fg": "#a59f85"
+    "fg": "#a59f85",
+    "match_fg": "#f4bf75",
+    "selected_fg": "#f8f8f2",
+    "selected_match_fg": "#f4bf75"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#75715e",
+    "layer0.tint": "#49483e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f5f4f1",
     "match_fg": "#f4bf75",
-    "selected_fg": "transparent",
+    "selected_fg": "#f9f8f5",
     "selected_match_fg": "#f4bf75",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#272822",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#49483e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#49483e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#75715e",
+    "layer0.tint": "#49483e",
+    "color_scheme_tint": "#49483e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-moonlight.sublime-theme
+++ b/base16-moonlight.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#403c64",
+    "layer1.tint": "#748cd6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#748cd6",
+    "layer2.tint": "#596399",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#748cd6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#748cd6",
+    "layer0.tint": "#596399",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a3ace13f",
+    "layer0.tint": "#748cd63f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#b4a4f4",
     "match_fg": "#ffc777",
-    "selected_fg": "#a1abe0",
+    "selected_fg": "#ef43fa",
     "selected_match_fg": "#ffc777"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#b4a4f4",
     "match_fg": "#ffc777",
-    "selected_fg": "#a1abe0",
+    "selected_fg": "#ef43fa",
     "selected_match_fg": "#ffc777"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#b4a4f4",
-    "match_fg": "#a3ace1",
-    "selected_fg": "#a1abe0",
-    "selected_match_fg": "#a1abe0"
+    "fg": "#a1abe0",
+    "match_fg": "#ffc777",
+    "selected_fg": "#a3ace1",
+    "selected_match_fg": "#ffc777"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#748cd6",
+    "layer0.tint": "#596399",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b4a4f4",
     "match_fg": "#ffc777",
-    "selected_fg": "transparent",
+    "selected_fg": "#ef43fa",
     "selected_match_fg": "#ffc777",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#212337",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#596399",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#596399",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#748cd6",
+    "layer0.tint": "#596399",
+    "color_scheme_tint": "#596399",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-mountain.sublime-theme
+++ b/base16-mountain.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#191919",
+    "layer1.tint": "#4c4c4c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#4c4c4c",
+    "layer2.tint": "#262626",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#4c4c4c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#4c4c4c",
+    "layer0.tint": "#262626",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cacaca3f",
+    "layer0.tint": "#4c4c4c3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e7e7e7",
     "match_fg": "#aca98a",
-    "selected_fg": "#ac8a8c",
+    "selected_fg": "#f0f0f0",
     "selected_match_fg": "#aca98a"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e7e7e7",
     "match_fg": "#aca98a",
-    "selected_fg": "#ac8a8c",
+    "selected_fg": "#f0f0f0",
     "selected_match_fg": "#aca98a"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e7e7e7",
-    "match_fg": "#cacaca",
-    "selected_fg": "#ac8a8c",
-    "selected_match_fg": "#ac8a8c"
+    "fg": "#ac8a8c",
+    "match_fg": "#aca98a",
+    "selected_fg": "#cacaca",
+    "selected_match_fg": "#aca98a"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#4c4c4c",
+    "layer0.tint": "#262626",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e7e7e7",
     "match_fg": "#aca98a",
-    "selected_fg": "transparent",
+    "selected_fg": "#f0f0f0",
     "selected_match_fg": "#aca98a",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0f0f0f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#262626",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#262626",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#4c4c4c",
+    "layer0.tint": "#262626",
+    "color_scheme_tint": "#262626",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-nebula.sublime-theme
+++ b/base16-nebula.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#414f60",
+    "layer1.tint": "#6e6f72",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6e6f72",
+    "layer2.tint": "#5a8380",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6e6f72",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6e6f72",
+    "layer0.tint": "#5a8380",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a4a6a93f",
+    "layer0.tint": "#6e6f723f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c7c9cd",
     "match_fg": "#4f9062",
-    "selected_fg": "#87888b",
+    "selected_fg": "#8dbdaa",
     "selected_match_fg": "#4f9062"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c7c9cd",
     "match_fg": "#4f9062",
-    "selected_fg": "#87888b",
+    "selected_fg": "#8dbdaa",
     "selected_match_fg": "#4f9062"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c7c9cd",
-    "match_fg": "#a4a6a9",
-    "selected_fg": "#87888b",
-    "selected_match_fg": "#87888b"
+    "fg": "#87888b",
+    "match_fg": "#4f9062",
+    "selected_fg": "#a4a6a9",
+    "selected_match_fg": "#4f9062"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6e6f72",
+    "layer0.tint": "#5a8380",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c7c9cd",
     "match_fg": "#4f9062",
-    "selected_fg": "transparent",
+    "selected_fg": "#8dbdaa",
     "selected_match_fg": "#4f9062",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#22273b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5a8380",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5a8380",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6e6f72",
+    "layer0.tint": "#5a8380",
+    "color_scheme_tint": "#5a8380",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-nord-light.sublime-theme
+++ b/base16-nord-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#b8c5db",
+    "layer0.tint": "#aebacf",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#c2d0e71e",
+    "layer1.tint": "#aebacf",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#aebacf",
+    "layer2.tint": "#b8c5db",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#aebacf",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#aebacf",
+    "layer0.tint": "#b8c5db",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#2e34401e",
+    "layer0.tint": "#aebacf1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#3b4252",
+    "fg": "#2e3440",
     "match_fg": "#9a7500",
-    "selected_fg": "#60728c",
+    "selected_fg": "#2e3440",
     "selected_match_fg": "#9a7500"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#3b4252",
+    "fg": "#2e3440",
     "match_fg": "#9a7500",
-    "selected_fg": "#60728c",
+    "selected_fg": "#2e3440",
     "selected_match_fg": "#9a7500"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#3b4252",
-    "match_fg": "#2e3440",
-    "selected_fg": "#60728c",
-    "selected_match_fg": "#60728c"
+    "fg": "#60728c",
+    "match_fg": "#9a7500",
+    "selected_fg": "#2e3440",
+    "selected_match_fg": "#9a7500"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#aebacf",
+    "layer0.tint": "#b8c5db",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#3b4252",
     "match_fg": "#9a7500",
-    "selected_fg": "transparent",
+    "selected_fg": "#29838d",
     "selected_match_fg": "#9a7500",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#e5e9f0",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#b8c5db",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#b8c5db",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#aebacf",
+    "layer0.tint": "#b8c5db",
+    "color_scheme_tint": "#b8c5db",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-nord.sublime-theme
+++ b/base16-nord.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3b4252",
+    "layer1.tint": "#4c566a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#4c566a",
+    "layer2.tint": "#434c5e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#4c566a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#4c566a",
+    "layer0.tint": "#434c5e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e5e9f03f",
+    "layer0.tint": "#4c566a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#eceff4",
     "match_fg": "#ebcb8b",
-    "selected_fg": "#d8dee9",
+    "selected_fg": "#8fbcbb",
     "selected_match_fg": "#ebcb8b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#eceff4",
     "match_fg": "#ebcb8b",
-    "selected_fg": "#d8dee9",
+    "selected_fg": "#8fbcbb",
     "selected_match_fg": "#ebcb8b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#eceff4",
-    "match_fg": "#e5e9f0",
-    "selected_fg": "#d8dee9",
-    "selected_match_fg": "#d8dee9"
+    "fg": "#d8dee9",
+    "match_fg": "#ebcb8b",
+    "selected_fg": "#e5e9f0",
+    "selected_match_fg": "#ebcb8b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#4c566a",
+    "layer0.tint": "#434c5e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eceff4",
     "match_fg": "#ebcb8b",
-    "selected_fg": "transparent",
+    "selected_fg": "#8fbcbb",
     "selected_match_fg": "#ebcb8b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2e3440",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#434c5e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#434c5e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#4c566a",
+    "layer0.tint": "#434c5e",
+    "color_scheme_tint": "#434c5e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-nova.sublime-theme
+++ b/base16-nova.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#556873",
+    "layer1.tint": "#899ba6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#899ba6",
+    "layer2.tint": "#6a7d89",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#899ba6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#899ba6",
+    "layer0.tint": "#6a7d89",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c5d4dd3f",
+    "layer0.tint": "#899ba63f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#899ba6",
     "match_fg": "#a8ce93",
-    "selected_fg": "#899ba6",
+    "selected_fg": "#556873",
     "selected_match_fg": "#a8ce93"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#899ba6",
     "match_fg": "#a8ce93",
-    "selected_fg": "#899ba6",
+    "selected_fg": "#556873",
     "selected_match_fg": "#a8ce93"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#899ba6",
-    "match_fg": "#c5d4dd",
-    "selected_fg": "#899ba6",
-    "selected_match_fg": "#899ba6"
+    "match_fg": "#a8ce93",
+    "selected_fg": "#c5d4dd",
+    "selected_match_fg": "#a8ce93"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#899ba6",
+    "layer0.tint": "#6a7d89",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#899ba6",
     "match_fg": "#a8ce93",
-    "selected_fg": "transparent",
+    "selected_fg": "#556873",
     "selected_match_fg": "#a8ce93",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#3c4c55",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#6a7d89",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#6a7d89",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#899ba6",
+    "layer0.tint": "#6a7d89",
+    "color_scheme_tint": "#6a7d89",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-ocean.sublime-theme
+++ b/base16-ocean.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#343d46",
+    "layer1.tint": "#65737e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#65737e",
+    "layer2.tint": "#4f5b66",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#65737e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#65737e",
+    "layer0.tint": "#4f5b66",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c0c5ce3f",
+    "layer0.tint": "#65737e3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dfe1e8",
     "match_fg": "#ebcb8b",
-    "selected_fg": "#a7adba",
+    "selected_fg": "#eff1f5",
     "selected_match_fg": "#ebcb8b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dfe1e8",
     "match_fg": "#ebcb8b",
-    "selected_fg": "#a7adba",
+    "selected_fg": "#eff1f5",
     "selected_match_fg": "#ebcb8b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dfe1e8",
-    "match_fg": "#c0c5ce",
-    "selected_fg": "#a7adba",
-    "selected_match_fg": "#a7adba"
+    "fg": "#a7adba",
+    "match_fg": "#ebcb8b",
+    "selected_fg": "#c0c5ce",
+    "selected_match_fg": "#ebcb8b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#65737e",
+    "layer0.tint": "#4f5b66",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dfe1e8",
     "match_fg": "#ebcb8b",
-    "selected_fg": "transparent",
+    "selected_fg": "#eff1f5",
     "selected_match_fg": "#ebcb8b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2b303b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4f5b66",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4f5b66",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#65737e",
+    "layer0.tint": "#4f5b66",
+    "color_scheme_tint": "#4f5b66",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-oceanicnext.sublime-theme
+++ b/base16-oceanicnext.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#343d46",
+    "layer1.tint": "#65737e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#65737e",
+    "layer2.tint": "#4f5b66",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#65737e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#65737e",
+    "layer0.tint": "#4f5b66",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c0c5ce3f",
+    "layer0.tint": "#65737e3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cdd3de",
     "match_fg": "#fac863",
-    "selected_fg": "#a7adba",
+    "selected_fg": "#d8dee9",
     "selected_match_fg": "#fac863"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cdd3de",
     "match_fg": "#fac863",
-    "selected_fg": "#a7adba",
+    "selected_fg": "#d8dee9",
     "selected_match_fg": "#fac863"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cdd3de",
-    "match_fg": "#c0c5ce",
-    "selected_fg": "#a7adba",
-    "selected_match_fg": "#a7adba"
+    "fg": "#a7adba",
+    "match_fg": "#fac863",
+    "selected_fg": "#c0c5ce",
+    "selected_match_fg": "#fac863"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#65737e",
+    "layer0.tint": "#4f5b66",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cdd3de",
     "match_fg": "#fac863",
-    "selected_fg": "transparent",
+    "selected_fg": "#d8dee9",
     "selected_match_fg": "#fac863",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1b2b34",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4f5b66",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4f5b66",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#65737e",
+    "layer0.tint": "#4f5b66",
+    "color_scheme_tint": "#4f5b66",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-one-light.sublime-theme
+++ b/base16-one-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#e5e5e6",
+    "layer0.tint": "#a0a1a7",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f0f0f11e",
+    "layer1.tint": "#a0a1a7",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#a0a1a7",
+    "layer2.tint": "#e5e5e6",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#a0a1a7",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#a0a1a7",
+    "layer0.tint": "#e5e5e6",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#383a421e",
+    "layer0.tint": "#a0a1a71e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#202227",
+    "fg": "#383a42",
     "match_fg": "#c18401",
-    "selected_fg": "#696c77",
+    "selected_fg": "#383a42",
     "selected_match_fg": "#c18401"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#202227",
+    "fg": "#383a42",
     "match_fg": "#c18401",
-    "selected_fg": "#696c77",
+    "selected_fg": "#383a42",
     "selected_match_fg": "#c18401"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#202227",
-    "match_fg": "#383a42",
-    "selected_fg": "#696c77",
-    "selected_match_fg": "#696c77"
+    "fg": "#696c77",
+    "match_fg": "#c18401",
+    "selected_fg": "#383a42",
+    "selected_match_fg": "#c18401"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#a0a1a7",
+    "layer0.tint": "#e5e5e6",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#202227",
     "match_fg": "#c18401",
-    "selected_fg": "transparent",
+    "selected_fg": "#090a0b",
     "selected_match_fg": "#c18401",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fafafa",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#e5e5e6",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#e5e5e6",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#a0a1a7",
+    "layer0.tint": "#e5e5e6",
+    "color_scheme_tint": "#e5e5e6",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-onedark-dark.sublime-theme
+++ b/base16-onedark-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1c1f24",
+    "layer1.tint": "#434852",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#434852",
+    "layer2.tint": "#2c313a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#434852",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#434852",
+    "layer0.tint": "#2c313a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#abb2bf3f",
+    "layer0.tint": "#4348523f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#b6bdca",
     "match_fg": "#e5c07b",
-    "selected_fg": "#565c64",
+    "selected_fg": "#c8ccd4",
     "selected_match_fg": "#e5c07b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#b6bdca",
     "match_fg": "#e5c07b",
-    "selected_fg": "#565c64",
+    "selected_fg": "#c8ccd4",
     "selected_match_fg": "#e5c07b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#b6bdca",
-    "match_fg": "#abb2bf",
-    "selected_fg": "#565c64",
-    "selected_match_fg": "#565c64"
+    "fg": "#565c64",
+    "match_fg": "#e5c07b",
+    "selected_fg": "#abb2bf",
+    "selected_match_fg": "#e5c07b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#434852",
+    "layer0.tint": "#2c313a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b6bdca",
     "match_fg": "#e5c07b",
-    "selected_fg": "transparent",
+    "selected_fg": "#c8ccd4",
     "selected_match_fg": "#e5c07b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2c313a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2c313a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#434852",
+    "layer0.tint": "#2c313a",
+    "color_scheme_tint": "#2c313a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-onedark.sublime-theme
+++ b/base16-onedark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#353b45",
+    "layer1.tint": "#545862",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#545862",
+    "layer2.tint": "#3e4451",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#545862",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#545862",
+    "layer0.tint": "#3e4451",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#abb2bf3f",
+    "layer0.tint": "#5458623f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#b6bdca",
     "match_fg": "#e5c07b",
-    "selected_fg": "#565c64",
+    "selected_fg": "#c8ccd4",
     "selected_match_fg": "#e5c07b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#b6bdca",
     "match_fg": "#e5c07b",
-    "selected_fg": "#565c64",
+    "selected_fg": "#c8ccd4",
     "selected_match_fg": "#e5c07b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#b6bdca",
-    "match_fg": "#abb2bf",
-    "selected_fg": "#565c64",
-    "selected_match_fg": "#565c64"
+    "fg": "#565c64",
+    "match_fg": "#e5c07b",
+    "selected_fg": "#abb2bf",
+    "selected_match_fg": "#e5c07b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#545862",
+    "layer0.tint": "#3e4451",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b6bdca",
     "match_fg": "#e5c07b",
-    "selected_fg": "transparent",
+    "selected_fg": "#c8ccd4",
     "selected_match_fg": "#e5c07b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#282c34",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3e4451",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3e4451",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#545862",
+    "layer0.tint": "#3e4451",
+    "color_scheme_tint": "#3e4451",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-outrun-dark.sublime-theme
+++ b/base16-outrun-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#20204a",
+    "layer1.tint": "#50507a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#50507a",
+    "layer2.tint": "#30305a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#50507a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#50507a",
+    "layer0.tint": "#30305a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0d0fa3f",
+    "layer0.tint": "#50507a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0ff",
     "match_fg": "#f3e877",
-    "selected_fg": "#b0b0da",
+    "selected_fg": "#f5f5ff",
     "selected_match_fg": "#f3e877"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0ff",
     "match_fg": "#f3e877",
-    "selected_fg": "#b0b0da",
+    "selected_fg": "#f5f5ff",
     "selected_match_fg": "#f3e877"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0ff",
-    "match_fg": "#d0d0fa",
-    "selected_fg": "#b0b0da",
-    "selected_match_fg": "#b0b0da"
+    "fg": "#b0b0da",
+    "match_fg": "#f3e877",
+    "selected_fg": "#d0d0fa",
+    "selected_match_fg": "#f3e877"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#50507a",
+    "layer0.tint": "#30305a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0ff",
     "match_fg": "#f3e877",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5f5ff",
     "selected_match_fg": "#f3e877",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#00002a",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#30305a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#30305a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#50507a",
+    "layer0.tint": "#30305a",
+    "color_scheme_tint": "#30305a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-oxocarbon-dark.sublime-theme
+++ b/base16-oxocarbon-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#262626",
+    "layer1.tint": "#525252",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#525252",
+    "layer2.tint": "#393939",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#525252",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#525252",
+    "layer0.tint": "#393939",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#f2f4f83f",
+    "layer0.tint": "#5252523f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffffff",
     "match_fg": "#ee5396",
-    "selected_fg": "#dde1e6",
+    "selected_fg": "#08bdba",
     "selected_match_fg": "#ee5396"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffffff",
     "match_fg": "#ee5396",
-    "selected_fg": "#dde1e6",
+    "selected_fg": "#08bdba",
     "selected_match_fg": "#ee5396"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffffff",
-    "match_fg": "#f2f4f8",
-    "selected_fg": "#dde1e6",
-    "selected_match_fg": "#dde1e6"
+    "fg": "#dde1e6",
+    "match_fg": "#ee5396",
+    "selected_fg": "#f2f4f8",
+    "selected_match_fg": "#ee5396"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#525252",
+    "layer0.tint": "#393939",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffffff",
     "match_fg": "#ee5396",
-    "selected_fg": "transparent",
+    "selected_fg": "#08bdba",
     "selected_match_fg": "#ee5396",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#161616",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#393939",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#393939",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#525252",
+    "layer0.tint": "#393939",
+    "color_scheme_tint": "#393939",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-oxocarbon-light.sublime-theme
+++ b/base16-oxocarbon-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#525252",
+    "layer0.tint": "#161616",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#dde1e61e",
+    "layer1.tint": "#161616",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#161616",
+    "layer2.tint": "#525252",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#161616",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#161616",
+    "layer0.tint": "#525252",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3939391e",
+    "layer0.tint": "#1616161e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#525252",
+    "fg": "#393939",
     "match_fg": "#ff6f00",
-    "selected_fg": "#262626",
+    "selected_fg": "#393939",
     "selected_match_fg": "#ff6f00"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#525252",
+    "fg": "#393939",
     "match_fg": "#ff6f00",
-    "selected_fg": "#262626",
+    "selected_fg": "#393939",
     "selected_match_fg": "#ff6f00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#525252",
-    "match_fg": "#393939",
-    "selected_fg": "#262626",
-    "selected_match_fg": "#262626"
+    "fg": "#262626",
+    "match_fg": "#ff6f00",
+    "selected_fg": "#393939",
+    "selected_match_fg": "#ff6f00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#161616",
+    "layer0.tint": "#525252",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#525252",
     "match_fg": "#ff6f00",
-    "selected_fg": "transparent",
+    "selected_fg": "#08bdba",
     "selected_match_fg": "#ff6f00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f2f4f8",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#525252",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#525252",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#161616",
+    "layer0.tint": "#525252",
+    "color_scheme_tint": "#525252",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-pandora.sublime-theme
+++ b/base16-pandora.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2f1823",
+    "layer1.tint": "#ffbee3",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#ffbee3",
+    "layer2.tint": "#472234",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#ffbee3",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#ffbee3",
+    "layer0.tint": "#472234",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#f15c993f",
+    "layer0.tint": "#ffbee33f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#81506a",
     "match_fg": "#ffcc00",
-    "selected_fg": "#9b2a46",
+    "selected_fg": "#632227",
     "selected_match_fg": "#ffcc00"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#81506a",
     "match_fg": "#ffcc00",
-    "selected_fg": "#9b2a46",
+    "selected_fg": "#632227",
     "selected_match_fg": "#ffcc00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#81506a",
-    "match_fg": "#f15c99",
-    "selected_fg": "#9b2a46",
-    "selected_match_fg": "#9b2a46"
+    "fg": "#9b2a46",
+    "match_fg": "#ffcc00",
+    "selected_fg": "#f15c99",
+    "selected_match_fg": "#ffcc00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#ffbee3",
+    "layer0.tint": "#472234",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#81506a",
     "match_fg": "#ffcc00",
-    "selected_fg": "transparent",
+    "selected_fg": "#632227",
     "selected_match_fg": "#ffcc00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#131213",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#472234",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#472234",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#ffbee3",
+    "layer0.tint": "#472234",
+    "color_scheme_tint": "#472234",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-papercolor-dark.sublime-theme
+++ b/base16-papercolor-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#af005f",
+    "layer1.tint": "#d7af5f",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#d7af5f",
+    "layer2.tint": "#5faf00",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#d7af5f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#d7af5f",
+    "layer0.tint": "#5faf00",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8080803f",
+    "layer0.tint": "#d7af5f3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d7875f",
     "match_fg": "#afd700",
-    "selected_fg": "#5fafd7",
+    "selected_fg": "#d0d0d0",
     "selected_match_fg": "#afd700"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d7875f",
     "match_fg": "#afd700",
-    "selected_fg": "#5fafd7",
+    "selected_fg": "#d0d0d0",
     "selected_match_fg": "#afd700"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d7875f",
-    "match_fg": "#808080",
-    "selected_fg": "#5fafd7",
-    "selected_match_fg": "#5fafd7"
+    "fg": "#5fafd7",
+    "match_fg": "#afd700",
+    "selected_fg": "#808080",
+    "selected_match_fg": "#afd700"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#d7af5f",
+    "layer0.tint": "#5faf00",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d7875f",
     "match_fg": "#afd700",
-    "selected_fg": "transparent",
+    "selected_fg": "#d0d0d0",
     "selected_match_fg": "#afd700",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1c1c1c",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5faf00",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5faf00",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#d7af5f",
+    "layer0.tint": "#5faf00",
+    "color_scheme_tint": "#5faf00",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-papercolor-light.sublime-theme
+++ b/base16-papercolor-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#008700",
+    "layer0.tint": "#5f8700",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#af00001e",
+    "layer1.tint": "#5f8700",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5f8700",
+    "layer2.tint": "#008700",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5f8700",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5f8700",
+    "layer0.tint": "#008700",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4444441e",
+    "layer0.tint": "#5f87001e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#005f87",
+    "fg": "#444444",
     "match_fg": "#d70087",
-    "selected_fg": "#0087af",
+    "selected_fg": "#444444",
     "selected_match_fg": "#d70087"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#005f87",
+    "fg": "#444444",
     "match_fg": "#d70087",
-    "selected_fg": "#0087af",
+    "selected_fg": "#444444",
     "selected_match_fg": "#d70087"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#005f87",
-    "match_fg": "#444444",
-    "selected_fg": "#0087af",
-    "selected_match_fg": "#0087af"
+    "fg": "#0087af",
+    "match_fg": "#d70087",
+    "selected_fg": "#444444",
+    "selected_match_fg": "#d70087"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5f8700",
+    "layer0.tint": "#008700",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#005f87",
     "match_fg": "#d70087",
-    "selected_fg": "transparent",
+    "selected_fg": "#878787",
     "selected_match_fg": "#d70087",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#eeeeee",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#008700",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#008700",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5f8700",
+    "layer0.tint": "#008700",
+    "color_scheme_tint": "#008700",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-paraiso.sublime-theme
+++ b/base16-paraiso.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#41323f",
+    "layer1.tint": "#776e71",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#776e71",
+    "layer2.tint": "#4f424c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#776e71",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#776e71",
+    "layer0.tint": "#4f424c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a39e9b3f",
+    "layer0.tint": "#776e713f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#b9b6b0",
     "match_fg": "#fec418",
-    "selected_fg": "#8d8687",
+    "selected_fg": "#e7e9db",
     "selected_match_fg": "#fec418"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#b9b6b0",
     "match_fg": "#fec418",
-    "selected_fg": "#8d8687",
+    "selected_fg": "#e7e9db",
     "selected_match_fg": "#fec418"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#b9b6b0",
-    "match_fg": "#a39e9b",
-    "selected_fg": "#8d8687",
-    "selected_match_fg": "#8d8687"
+    "fg": "#8d8687",
+    "match_fg": "#fec418",
+    "selected_fg": "#a39e9b",
+    "selected_match_fg": "#fec418"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#776e71",
+    "layer0.tint": "#4f424c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b9b6b0",
     "match_fg": "#fec418",
-    "selected_fg": "transparent",
+    "selected_fg": "#e7e9db",
     "selected_match_fg": "#fec418",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2f1e2e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4f424c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4f424c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#776e71",
+    "layer0.tint": "#4f424c",
+    "color_scheme_tint": "#4f424c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-pasque.sublime-theme
+++ b/base16-pasque.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#100323",
+    "layer1.tint": "#5d5766",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5d5766",
+    "layer2.tint": "#3e2d5c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5d5766",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5d5766",
+    "layer0.tint": "#3e2d5c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#dedcdf3f",
+    "layer0.tint": "#5d57663f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#edeaef",
     "match_fg": "#804ead",
-    "selected_fg": "#bebcbf",
+    "selected_fg": "#bbaadd",
     "selected_match_fg": "#804ead"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#edeaef",
     "match_fg": "#804ead",
-    "selected_fg": "#bebcbf",
+    "selected_fg": "#bbaadd",
     "selected_match_fg": "#804ead"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#edeaef",
-    "match_fg": "#dedcdf",
-    "selected_fg": "#bebcbf",
-    "selected_match_fg": "#bebcbf"
+    "fg": "#bebcbf",
+    "match_fg": "#804ead",
+    "selected_fg": "#dedcdf",
+    "selected_match_fg": "#804ead"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5d5766",
+    "layer0.tint": "#3e2d5c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#edeaef",
     "match_fg": "#804ead",
-    "selected_fg": "transparent",
+    "selected_fg": "#bbaadd",
     "selected_match_fg": "#804ead",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#271c3a",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3e2d5c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3e2d5c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5d5766",
+    "layer0.tint": "#3e2d5c",
+    "color_scheme_tint": "#3e2d5c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-phd.sublime-theme
+++ b/base16-phd.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2a3448",
+    "layer1.tint": "#717885",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#717885",
+    "layer2.tint": "#4d5666",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#717885",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#717885",
+    "layer0.tint": "#4d5666",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b8bbc23f",
+    "layer0.tint": "#7178853f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dbdde0",
     "match_fg": "#fbd461",
-    "selected_fg": "#9a99a3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbd461"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dbdde0",
     "match_fg": "#fbd461",
-    "selected_fg": "#9a99a3",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbd461"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dbdde0",
-    "match_fg": "#b8bbc2",
-    "selected_fg": "#9a99a3",
-    "selected_match_fg": "#9a99a3"
+    "fg": "#9a99a3",
+    "match_fg": "#fbd461",
+    "selected_fg": "#b8bbc2",
+    "selected_match_fg": "#fbd461"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#717885",
+    "layer0.tint": "#4d5666",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dbdde0",
     "match_fg": "#fbd461",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbd461",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#061229",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4d5666",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4d5666",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#717885",
+    "layer0.tint": "#4d5666",
+    "color_scheme_tint": "#4d5666",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-pico.sublime-theme
+++ b/base16-pico.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1d2b53",
+    "layer1.tint": "#008751",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#008751",
+    "layer2.tint": "#7e2553",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#008751",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#008751",
+    "layer0.tint": "#7e2553",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5f574f3f",
+    "layer0.tint": "#0087513f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c2c3c7",
     "match_fg": "#fff024",
-    "selected_fg": "#ab5236",
+    "selected_fg": "#fff1e8",
     "selected_match_fg": "#fff024"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c2c3c7",
     "match_fg": "#fff024",
-    "selected_fg": "#ab5236",
+    "selected_fg": "#fff1e8",
     "selected_match_fg": "#fff024"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c2c3c7",
-    "match_fg": "#5f574f",
-    "selected_fg": "#ab5236",
-    "selected_match_fg": "#ab5236"
+    "fg": "#ab5236",
+    "match_fg": "#fff024",
+    "selected_fg": "#5f574f",
+    "selected_match_fg": "#fff024"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#008751",
+    "layer0.tint": "#7e2553",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c2c3c7",
     "match_fg": "#fff024",
-    "selected_fg": "transparent",
+    "selected_fg": "#fff1e8",
     "selected_match_fg": "#fff024",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#7e2553",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#7e2553",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#008751",
+    "layer0.tint": "#7e2553",
+    "color_scheme_tint": "#7e2553",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-pinky.sublime-theme
+++ b/base16-pinky.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1b181b",
+    "layer1.tint": "#383338",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#383338",
+    "layer2.tint": "#1d1b1d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#383338",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#383338",
+    "layer0.tint": "#1d1b1d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#f5f5f53f",
+    "layer0.tint": "#3833383f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ffffff",
     "match_fg": "#20df6c",
-    "selected_fg": "#e7dbdb",
+    "selected_fg": "#f7f3f7",
     "selected_match_fg": "#20df6c"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ffffff",
     "match_fg": "#20df6c",
-    "selected_fg": "#e7dbdb",
+    "selected_fg": "#f7f3f7",
     "selected_match_fg": "#20df6c"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ffffff",
-    "match_fg": "#f5f5f5",
-    "selected_fg": "#e7dbdb",
-    "selected_match_fg": "#e7dbdb"
+    "fg": "#e7dbdb",
+    "match_fg": "#20df6c",
+    "selected_fg": "#f5f5f5",
+    "selected_match_fg": "#20df6c"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#383338",
+    "layer0.tint": "#1d1b1d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffffff",
     "match_fg": "#20df6c",
-    "selected_fg": "transparent",
+    "selected_fg": "#f7f3f7",
     "selected_match_fg": "#20df6c",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#171517",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#1d1b1d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#1d1b1d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#383338",
+    "layer0.tint": "#1d1b1d",
+    "color_scheme_tint": "#1d1b1d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-pop.sublime-theme
+++ b/base16-pop.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#202020",
+    "layer1.tint": "#505050",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#505050",
+    "layer2.tint": "#303030",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#505050",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0d0d03f",
+    "layer0.tint": "#5050503f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#f8ca12",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f8ca12"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#f8ca12",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f8ca12"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#d0d0d0",
-    "selected_fg": "#b0b0b0",
-    "selected_match_fg": "#b0b0b0"
+    "fg": "#b0b0b0",
+    "match_fg": "#f8ca12",
+    "selected_fg": "#d0d0d0",
+    "selected_match_fg": "#f8ca12"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#f8ca12",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f8ca12",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
+    "color_scheme_tint": "#303030",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-porple.sublime-theme
+++ b/base16-porple.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#333344",
+    "layer1.tint": "#65568a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#65568a",
+    "layer2.tint": "#474160",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#65568a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#65568a",
+    "layer0.tint": "#474160",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d8d8d83f",
+    "layer0.tint": "#65568a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e8e8",
     "match_fg": "#efa16b",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#efa16b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e8e8",
     "match_fg": "#efa16b",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#efa16b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e8e8",
-    "match_fg": "#d8d8d8",
-    "selected_fg": "#b8b8b8",
-    "selected_match_fg": "#b8b8b8"
+    "fg": "#b8b8b8",
+    "match_fg": "#efa16b",
+    "selected_fg": "#d8d8d8",
+    "selected_match_fg": "#efa16b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#65568a",
+    "layer0.tint": "#474160",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e8e8",
     "match_fg": "#efa16b",
-    "selected_fg": "transparent",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#efa16b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#292c36",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#474160",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#474160",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#65568a",
+    "layer0.tint": "#474160",
+    "color_scheme_tint": "#474160",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-precious-dark-eleven.sublime-theme
+++ b/base16-precious-dark-eleven.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#292b2d",
+    "layer1.tint": "#858585",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#858585",
+    "layer2.tint": "#37393a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#858585",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#858585",
+    "layer0.tint": "#37393a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b8b7b63f",
+    "layer0.tint": "#8585853f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#b8b7b6",
     "match_fg": "#d0a543",
-    "selected_fg": "#a8a8a7",
+    "selected_fg": "#b8b7b6",
     "selected_match_fg": "#d0a543"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#b8b7b6",
     "match_fg": "#d0a543",
-    "selected_fg": "#a8a8a7",
+    "selected_fg": "#b8b7b6",
     "selected_match_fg": "#d0a543"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#b8b7b6",
-    "match_fg": "#b8b7b6",
-    "selected_fg": "#a8a8a7",
-    "selected_match_fg": "#a8a8a7"
+    "fg": "#a8a8a7",
+    "match_fg": "#d0a543",
+    "selected_fg": "#b8b7b6",
+    "selected_match_fg": "#d0a543"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#858585",
+    "layer0.tint": "#37393a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b8b7b6",
     "match_fg": "#d0a543",
-    "selected_fg": "transparent",
+    "selected_fg": "#b8b7b6",
     "selected_match_fg": "#d0a543",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1c1e20",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#37393a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#37393a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#858585",
+    "layer0.tint": "#37393a",
+    "color_scheme_tint": "#37393a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-precious-dark-fifteen.sublime-theme
+++ b/base16-precious-dark-fifteen.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#303337",
+    "layer1.tint": "#898989",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#898989",
+    "layer2.tint": "#3e4044",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#898989",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#898989",
+    "layer0.tint": "#3e4044",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#bab9b63f",
+    "layer0.tint": "#8989893f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#bab9b6",
     "match_fg": "#cfa546",
-    "selected_fg": "#abaaa8",
+    "selected_fg": "#bab9b6",
     "selected_match_fg": "#cfa546"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#bab9b6",
     "match_fg": "#cfa546",
-    "selected_fg": "#abaaa8",
+    "selected_fg": "#bab9b6",
     "selected_match_fg": "#cfa546"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#bab9b6",
-    "match_fg": "#bab9b6",
-    "selected_fg": "#abaaa8",
-    "selected_match_fg": "#abaaa8"
+    "fg": "#abaaa8",
+    "match_fg": "#cfa546",
+    "selected_fg": "#bab9b6",
+    "selected_match_fg": "#cfa546"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#898989",
+    "layer0.tint": "#3e4044",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#bab9b6",
     "match_fg": "#cfa546",
-    "selected_fg": "transparent",
+    "selected_fg": "#bab9b6",
     "selected_match_fg": "#cfa546",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#23262b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3e4044",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3e4044",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#898989",
+    "layer0.tint": "#3e4044",
+    "color_scheme_tint": "#3e4044",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-precious-light-warm.sublime-theme
+++ b/base16-precious-light-warm.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d9d3c8",
+    "layer0.tint": "#7f8080",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ece4d61e",
+    "layer1.tint": "#7f8080",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7f8080",
+    "layer2.tint": "#d9d3c8",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7f8080",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7f8080",
+    "layer0.tint": "#d9d3c8",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4e53591e",
+    "layer0.tint": "#7f80801e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#4e5359",
     "match_fg": "#876500",
-    "selected_fg": "#5d6065",
+    "selected_fg": "#4e5359",
     "selected_match_fg": "#876500"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#4e5359",
     "match_fg": "#876500",
-    "selected_fg": "#5d6065",
+    "selected_fg": "#4e5359",
     "selected_match_fg": "#876500"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#4e5359",
-    "match_fg": "#4e5359",
-    "selected_fg": "#5d6065",
-    "selected_match_fg": "#5d6065"
+    "fg": "#5d6065",
+    "match_fg": "#876500",
+    "selected_fg": "#4e5359",
+    "selected_match_fg": "#876500"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7f8080",
+    "layer0.tint": "#d9d3c8",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#4e5359",
     "match_fg": "#876500",
-    "selected_fg": "transparent",
+    "selected_fg": "#4e5359",
     "selected_match_fg": "#876500",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fff5e5",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d9d3c8",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d9d3c8",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7f8080",
+    "layer0.tint": "#d9d3c8",
+    "color_scheme_tint": "#d9d3c8",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-precious-light-white.sublime-theme
+++ b/base16-precious-light-white.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#dbdbdb",
+    "layer0.tint": "#848484",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ededed1e",
+    "layer1.tint": "#848484",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#848484",
+    "layer2.tint": "#dbdbdb",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#848484",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#848484",
+    "layer0.tint": "#dbdbdb",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5555551e",
+    "layer0.tint": "#8484841e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#555555",
     "match_fg": "#876500",
-    "selected_fg": "#636363",
+    "selected_fg": "#555555",
     "selected_match_fg": "#876500"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#555555",
     "match_fg": "#876500",
-    "selected_fg": "#636363",
+    "selected_fg": "#555555",
     "selected_match_fg": "#876500"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#555555",
-    "match_fg": "#555555",
-    "selected_fg": "#636363",
-    "selected_match_fg": "#636363"
+    "fg": "#636363",
+    "match_fg": "#876500",
+    "selected_fg": "#555555",
+    "selected_match_fg": "#876500"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#848484",
+    "layer0.tint": "#dbdbdb",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#555555",
     "match_fg": "#876500",
-    "selected_fg": "transparent",
+    "selected_fg": "#555555",
     "selected_match_fg": "#876500",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#dbdbdb",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#dbdbdb",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#848484",
+    "layer0.tint": "#dbdbdb",
+    "color_scheme_tint": "#dbdbdb",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-primer-dark-dimmed.sublime-theme
+++ b/base16-primer-dark-dimmed.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#373e47",
+    "layer1.tint": "#545d68",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#545d68",
+    "layer2.tint": "#444c56",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#545d68",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#545d68",
+    "layer0.tint": "#444c56",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#909dab3f",
+    "layer0.tint": "#545d683f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#adbac7",
     "match_fg": "#c69026",
-    "selected_fg": "#768390",
+    "selected_fg": "#cdd9e5",
     "selected_match_fg": "#c69026"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#adbac7",
     "match_fg": "#c69026",
-    "selected_fg": "#768390",
+    "selected_fg": "#cdd9e5",
     "selected_match_fg": "#c69026"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#adbac7",
-    "match_fg": "#909dab",
-    "selected_fg": "#768390",
-    "selected_match_fg": "#768390"
+    "fg": "#768390",
+    "match_fg": "#c69026",
+    "selected_fg": "#909dab",
+    "selected_match_fg": "#c69026"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#545d68",
+    "layer0.tint": "#444c56",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#adbac7",
     "match_fg": "#c69026",
-    "selected_fg": "transparent",
+    "selected_fg": "#cdd9e5",
     "selected_match_fg": "#c69026",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1c2128",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#444c56",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#444c56",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#545d68",
+    "layer0.tint": "#444c56",
+    "color_scheme_tint": "#444c56",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-primer-dark.sublime-theme
+++ b/base16-primer-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#21262d",
+    "layer1.tint": "#484f58",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#484f58",
+    "layer2.tint": "#30363d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#484f58",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#484f58",
+    "layer0.tint": "#30363d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b1bac43f",
+    "layer0.tint": "#484f583f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c9d1d9",
     "match_fg": "#d29922",
-    "selected_fg": "#8b949e",
+    "selected_fg": "#f0f6fc",
     "selected_match_fg": "#d29922"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c9d1d9",
     "match_fg": "#d29922",
-    "selected_fg": "#8b949e",
+    "selected_fg": "#f0f6fc",
     "selected_match_fg": "#d29922"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c9d1d9",
-    "match_fg": "#b1bac4",
-    "selected_fg": "#8b949e",
-    "selected_match_fg": "#8b949e"
+    "fg": "#8b949e",
+    "match_fg": "#d29922",
+    "selected_fg": "#b1bac4",
+    "selected_match_fg": "#d29922"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#484f58",
+    "layer0.tint": "#30363d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c9d1d9",
     "match_fg": "#d29922",
-    "selected_fg": "transparent",
+    "selected_fg": "#f0f6fc",
     "selected_match_fg": "#d29922",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#010409",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#30363d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#30363d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#484f58",
+    "layer0.tint": "#30363d",
+    "color_scheme_tint": "#30363d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-primer-light.sublime-theme
+++ b/base16-primer-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d1d5da",
+    "layer0.tint": "#959da5",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e1e4e81e",
+    "layer1.tint": "#959da5",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#959da5",
+    "layer2.tint": "#d1d5da",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#959da5",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#959da5",
+    "layer0.tint": "#d1d5da",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#2f363d1e",
+    "layer0.tint": "#959da51e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#24292e",
+    "fg": "#2f363d",
     "match_fg": "#ffd33d",
-    "selected_fg": "#444d56",
+    "selected_fg": "#2f363d",
     "selected_match_fg": "#ffd33d"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#24292e",
+    "fg": "#2f363d",
     "match_fg": "#ffd33d",
-    "selected_fg": "#444d56",
+    "selected_fg": "#2f363d",
     "selected_match_fg": "#ffd33d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#24292e",
-    "match_fg": "#2f363d",
-    "selected_fg": "#444d56",
-    "selected_match_fg": "#444d56"
+    "fg": "#444d56",
+    "match_fg": "#ffd33d",
+    "selected_fg": "#2f363d",
+    "selected_match_fg": "#ffd33d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#959da5",
+    "layer0.tint": "#d1d5da",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#24292e",
     "match_fg": "#ffd33d",
-    "selected_fg": "transparent",
+    "selected_fg": "#1b1f23",
     "selected_match_fg": "#ffd33d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fafbfc",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d1d5da",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d1d5da",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#959da5",
+    "layer0.tint": "#d1d5da",
+    "color_scheme_tint": "#d1d5da",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-purpledream.sublime-theme
+++ b/base16-purpledream.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#302030",
+    "layer1.tint": "#605060",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#605060",
+    "layer2.tint": "#403040",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#605060",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#605060",
+    "layer0.tint": "#403040",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ddd0dd3f",
+    "layer0.tint": "#6050603f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#eee0ee",
     "match_fg": "#f000a0",
-    "selected_fg": "#bbb0bb",
+    "selected_fg": "#fff0ff",
     "selected_match_fg": "#f000a0"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#eee0ee",
     "match_fg": "#f000a0",
-    "selected_fg": "#bbb0bb",
+    "selected_fg": "#fff0ff",
     "selected_match_fg": "#f000a0"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#eee0ee",
-    "match_fg": "#ddd0dd",
-    "selected_fg": "#bbb0bb",
-    "selected_match_fg": "#bbb0bb"
+    "fg": "#bbb0bb",
+    "match_fg": "#f000a0",
+    "selected_fg": "#ddd0dd",
+    "selected_match_fg": "#f000a0"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#605060",
+    "layer0.tint": "#403040",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eee0ee",
     "match_fg": "#f000a0",
-    "selected_fg": "transparent",
+    "selected_fg": "#fff0ff",
     "selected_match_fg": "#f000a0",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#100510",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#403040",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#403040",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#605060",
+    "layer0.tint": "#403040",
+    "color_scheme_tint": "#403040",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-qualia.sublime-theme
+++ b/base16-qualia.sublime-theme
@@ -571,12 +571,6 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#454545",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
     "layer0.tint": "#454545",
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c0c0c03f",
+    "layer0.tint": "#4545453f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c0c0c0",
     "match_fg": "#e6a3dc",
-    "selected_fg": "#808080",
+    "selected_fg": "#454545",
     "selected_match_fg": "#e6a3dc"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c0c0c0",
     "match_fg": "#e6a3dc",
-    "selected_fg": "#808080",
+    "selected_fg": "#454545",
     "selected_match_fg": "#e6a3dc"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c0c0c0",
-    "match_fg": "#c0c0c0",
-    "selected_fg": "#808080",
-    "selected_match_fg": "#808080"
+    "fg": "#808080",
+    "match_fg": "#e6a3dc",
+    "selected_fg": "#c0c0c0",
+    "selected_match_fg": "#e6a3dc"
   },
   {
     "class": "quick_panel_detail_label",
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c0c0c0",
     "match_fg": "#e6a3dc",
-    "selected_fg": "transparent",
+    "selected_fg": "#454545",
     "selected_match_fg": "#e6a3dc",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#101010",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#454545",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#454545",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1270,6 +1276,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#454545",
+    "color_scheme_tint": "#454545",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-railscasts.sublime-theme
+++ b/base16-railscasts.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#272935",
+    "layer1.tint": "#5a647e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5a647e",
+    "layer2.tint": "#3a4055",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5a647e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5a647e",
+    "layer0.tint": "#3a4055",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e6e1dc3f",
+    "layer0.tint": "#5a647e3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f4f1ed",
     "match_fg": "#ffc66d",
-    "selected_fg": "#d4cfc9",
+    "selected_fg": "#f9f7f3",
     "selected_match_fg": "#ffc66d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f4f1ed",
     "match_fg": "#ffc66d",
-    "selected_fg": "#d4cfc9",
+    "selected_fg": "#f9f7f3",
     "selected_match_fg": "#ffc66d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f4f1ed",
-    "match_fg": "#e6e1dc",
-    "selected_fg": "#d4cfc9",
-    "selected_match_fg": "#d4cfc9"
+    "fg": "#d4cfc9",
+    "match_fg": "#ffc66d",
+    "selected_fg": "#e6e1dc",
+    "selected_match_fg": "#ffc66d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5a647e",
+    "layer0.tint": "#3a4055",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f4f1ed",
     "match_fg": "#ffc66d",
-    "selected_fg": "transparent",
+    "selected_fg": "#f9f7f3",
     "selected_match_fg": "#ffc66d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2b2b2b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3a4055",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3a4055",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5a647e",
+    "layer0.tint": "#3a4055",
+    "color_scheme_tint": "#3a4055",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-rebecca.sublime-theme
+++ b/base16-rebecca.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#663399",
+    "layer1.tint": "#666699",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#666699",
+    "layer2.tint": "#383a62",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#666699",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#666699",
+    "layer0.tint": "#383a62",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#f1eff83f",
+    "layer0.tint": "#6666993f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ccccff",
     "match_fg": "#ae81ff",
-    "selected_fg": "#a0a0c5",
+    "selected_fg": "#53495d",
     "selected_match_fg": "#ae81ff"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ccccff",
     "match_fg": "#ae81ff",
-    "selected_fg": "#a0a0c5",
+    "selected_fg": "#53495d",
     "selected_match_fg": "#ae81ff"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ccccff",
-    "match_fg": "#f1eff8",
-    "selected_fg": "#a0a0c5",
-    "selected_match_fg": "#a0a0c5"
+    "fg": "#a0a0c5",
+    "match_fg": "#ae81ff",
+    "selected_fg": "#f1eff8",
+    "selected_match_fg": "#ae81ff"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#666699",
+    "layer0.tint": "#383a62",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ccccff",
     "match_fg": "#ae81ff",
-    "selected_fg": "transparent",
+    "selected_fg": "#53495d",
     "selected_match_fg": "#ae81ff",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#292a44",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#383a62",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#383a62",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#666699",
+    "layer0.tint": "#383a62",
+    "color_scheme_tint": "#383a62",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-rose-pine-dawn.sublime-theme
+++ b/base16-rose-pine-dawn.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#f2e9de",
+    "layer0.tint": "#9893a5",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#fffaf31e",
+    "layer1.tint": "#9893a5",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9893a5",
+    "layer2.tint": "#f2e9de",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9893a5",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9893a5",
+    "layer0.tint": "#f2e9de",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5752791e",
+    "layer0.tint": "#9893a51e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#575279",
     "match_fg": "#d7827e",
-    "selected_fg": "#797593",
+    "selected_fg": "#575279",
     "selected_match_fg": "#d7827e"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#575279",
     "match_fg": "#d7827e",
-    "selected_fg": "#797593",
+    "selected_fg": "#575279",
     "selected_match_fg": "#d7827e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#575279",
-    "match_fg": "#575279",
-    "selected_fg": "#797593",
-    "selected_match_fg": "#797593"
+    "fg": "#797593",
+    "match_fg": "#d7827e",
+    "selected_fg": "#575279",
+    "selected_match_fg": "#d7827e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9893a5",
+    "layer0.tint": "#f2e9de",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#575279",
     "match_fg": "#d7827e",
-    "selected_fg": "transparent",
+    "selected_fg": "#cecacd",
     "selected_match_fg": "#d7827e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#faf4ed",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#f2e9de",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#f2e9de",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9893a5",
+    "layer0.tint": "#f2e9de",
+    "color_scheme_tint": "#f2e9de",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-rose-pine-moon.sublime-theme
+++ b/base16-rose-pine-moon.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2a273f",
+    "layer1.tint": "#6e6a86",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6e6a86",
+    "layer2.tint": "#393552",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6e6a86",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6e6a86",
+    "layer0.tint": "#393552",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e0def43f",
+    "layer0.tint": "#6e6a863f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0def4",
     "match_fg": "#ea9a97",
-    "selected_fg": "#908caa",
+    "selected_fg": "#56526e",
     "selected_match_fg": "#ea9a97"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0def4",
     "match_fg": "#ea9a97",
-    "selected_fg": "#908caa",
+    "selected_fg": "#56526e",
     "selected_match_fg": "#ea9a97"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0def4",
-    "match_fg": "#e0def4",
-    "selected_fg": "#908caa",
-    "selected_match_fg": "#908caa"
+    "fg": "#908caa",
+    "match_fg": "#ea9a97",
+    "selected_fg": "#e0def4",
+    "selected_match_fg": "#ea9a97"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6e6a86",
+    "layer0.tint": "#393552",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0def4",
     "match_fg": "#ea9a97",
-    "selected_fg": "transparent",
+    "selected_fg": "#56526e",
     "selected_match_fg": "#ea9a97",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#232136",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#393552",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#393552",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6e6a86",
+    "layer0.tint": "#393552",
+    "color_scheme_tint": "#393552",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-rose-pine.sublime-theme
+++ b/base16-rose-pine.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1f1d2e",
+    "layer1.tint": "#6e6a86",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6e6a86",
+    "layer2.tint": "#26233a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6e6a86",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6e6a86",
+    "layer0.tint": "#26233a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e0def43f",
+    "layer0.tint": "#6e6a863f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0def4",
     "match_fg": "#ebbcba",
-    "selected_fg": "#908caa",
+    "selected_fg": "#524f67",
     "selected_match_fg": "#ebbcba"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0def4",
     "match_fg": "#ebbcba",
-    "selected_fg": "#908caa",
+    "selected_fg": "#524f67",
     "selected_match_fg": "#ebbcba"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0def4",
-    "match_fg": "#e0def4",
-    "selected_fg": "#908caa",
-    "selected_match_fg": "#908caa"
+    "fg": "#908caa",
+    "match_fg": "#ebbcba",
+    "selected_fg": "#e0def4",
+    "selected_match_fg": "#ebbcba"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6e6a86",
+    "layer0.tint": "#26233a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0def4",
     "match_fg": "#ebbcba",
-    "selected_fg": "transparent",
+    "selected_fg": "#524f67",
     "selected_match_fg": "#ebbcba",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#191724",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#26233a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#26233a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6e6a86",
+    "layer0.tint": "#26233a",
+    "color_scheme_tint": "#26233a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-saga.sublime-theme
+++ b/base16-saga.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#0a1014",
+    "layer1.tint": "#141f27",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#141f27",
+    "layer2.tint": "#0f181e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#141f27",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#141f27",
+    "layer0.tint": "#0f181e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#dce2f73f",
+    "layer0.tint": "#141f273f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f8eae7",
     "match_fg": "#fbebc8",
-    "selected_fg": "#192630",
+    "selected_fg": "#ccd3fe",
     "selected_match_fg": "#fbebc8"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f8eae7",
     "match_fg": "#fbebc8",
-    "selected_fg": "#192630",
+    "selected_fg": "#ccd3fe",
     "selected_match_fg": "#fbebc8"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f8eae7",
-    "match_fg": "#dce2f7",
-    "selected_fg": "#192630",
-    "selected_match_fg": "#192630"
+    "fg": "#192630",
+    "match_fg": "#fbebc8",
+    "selected_fg": "#dce2f7",
+    "selected_match_fg": "#fbebc8"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#141f27",
+    "layer0.tint": "#0f181e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f8eae7",
     "match_fg": "#fbebc8",
-    "selected_fg": "transparent",
+    "selected_fg": "#ccd3fe",
     "selected_match_fg": "#fbebc8",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#05080a",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#0f181e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#0f181e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#141f27",
+    "layer0.tint": "#0f181e",
+    "color_scheme_tint": "#0f181e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-sagelight.sublime-theme
+++ b/base16-sagelight.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d8d8d8",
+    "layer0.tint": "#b8b8b8",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e8e8e81e",
+    "layer1.tint": "#b8b8b8",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b8b8b8",
+    "layer2.tint": "#d8d8d8",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b8b8b8",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3838381e",
+    "layer0.tint": "#b8b8b81e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#282828",
+    "fg": "#383838",
     "match_fg": "#ffdc61",
-    "selected_fg": "#585858",
+    "selected_fg": "#383838",
     "selected_match_fg": "#ffdc61"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#282828",
+    "fg": "#383838",
     "match_fg": "#ffdc61",
-    "selected_fg": "#585858",
+    "selected_fg": "#383838",
     "selected_match_fg": "#ffdc61"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#282828",
-    "match_fg": "#383838",
-    "selected_fg": "#585858",
-    "selected_match_fg": "#585858"
+    "fg": "#585858",
+    "match_fg": "#ffdc61",
+    "selected_fg": "#383838",
+    "selected_match_fg": "#ffdc61"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#282828",
     "match_fg": "#ffdc61",
-    "selected_fg": "transparent",
+    "selected_fg": "#181818",
     "selected_match_fg": "#ffdc61",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f8f8f8",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d8d8d8",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d8d8d8",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b8b8b8",
+    "layer0.tint": "#d8d8d8",
+    "color_scheme_tint": "#d8d8d8",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-sakura.sublime-theme
+++ b/base16-sakura.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#e0ccd1",
+    "layer0.tint": "#755f64",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f8e2e71e",
+    "layer1.tint": "#755f64",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#755f64",
+    "layer2.tint": "#e0ccd1",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#755f64",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#755f64",
+    "layer0.tint": "#e0ccd1",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5644481e",
+    "layer0.tint": "#755f641e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#42383a",
+    "fg": "#564448",
     "match_fg": "#c29461",
-    "selected_fg": "#665055",
+    "selected_fg": "#564448",
     "selected_match_fg": "#c29461"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#42383a",
+    "fg": "#564448",
     "match_fg": "#c29461",
-    "selected_fg": "#665055",
+    "selected_fg": "#564448",
     "selected_match_fg": "#c29461"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#42383a",
-    "match_fg": "#564448",
-    "selected_fg": "#665055",
-    "selected_match_fg": "#665055"
+    "fg": "#665055",
+    "match_fg": "#c29461",
+    "selected_fg": "#564448",
+    "selected_match_fg": "#c29461"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#755f64",
+    "layer0.tint": "#e0ccd1",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#42383a",
     "match_fg": "#c29461",
-    "selected_fg": "transparent",
+    "selected_fg": "#33292b",
     "selected_match_fg": "#c29461",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#feedf3",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#e0ccd1",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#e0ccd1",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#755f64",
+    "layer0.tint": "#e0ccd1",
+    "color_scheme_tint": "#e0ccd1",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-sandcastle.sublime-theme
+++ b/base16-sandcastle.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2c323b",
+    "layer1.tint": "#665c54",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#665c54",
+    "layer2.tint": "#3e4451",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#3e4451",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a899843f",
+    "layer0.tint": "#665c543f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d5c4a1",
     "match_fg": "#a07e3b",
-    "selected_fg": "#928374",
+    "selected_fg": "#fdf4c1",
     "selected_match_fg": "#a07e3b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d5c4a1",
     "match_fg": "#a07e3b",
-    "selected_fg": "#928374",
+    "selected_fg": "#fdf4c1",
     "selected_match_fg": "#a07e3b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d5c4a1",
-    "match_fg": "#a89984",
-    "selected_fg": "#928374",
-    "selected_match_fg": "#928374"
+    "fg": "#928374",
+    "match_fg": "#a07e3b",
+    "selected_fg": "#a89984",
+    "selected_match_fg": "#a07e3b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#3e4451",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d5c4a1",
     "match_fg": "#a07e3b",
-    "selected_fg": "transparent",
+    "selected_fg": "#fdf4c1",
     "selected_match_fg": "#a07e3b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#282c34",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3e4451",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3e4451",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#665c54",
+    "layer0.tint": "#3e4451",
+    "color_scheme_tint": "#3e4451",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-selenized-black.sublime-theme
+++ b/base16-selenized-black.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#252525",
+    "layer1.tint": "#777777",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#777777",
+    "layer2.tint": "#3b3b3b",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#777777",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#3b3b3b",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b9b9b93f",
+    "layer0.tint": "#7777773f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dedede",
     "match_fg": "#dbb32d",
-    "selected_fg": "#777777",
+    "selected_fg": "#dedede",
     "selected_match_fg": "#dbb32d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dedede",
     "match_fg": "#dbb32d",
-    "selected_fg": "#777777",
+    "selected_fg": "#dedede",
     "selected_match_fg": "#dbb32d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dedede",
-    "match_fg": "#b9b9b9",
-    "selected_fg": "#777777",
-    "selected_match_fg": "#777777"
+    "fg": "#777777",
+    "match_fg": "#dbb32d",
+    "selected_fg": "#b9b9b9",
+    "selected_match_fg": "#dbb32d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#777777",
+    "layer0.tint": "#3b3b3b",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dedede",
     "match_fg": "#dbb32d",
-    "selected_fg": "transparent",
+    "selected_fg": "#dedede",
     "selected_match_fg": "#dbb32d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#181818",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3b3b3b",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3b3b3b",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#777777",
+    "layer0.tint": "#3b3b3b",
+    "color_scheme_tint": "#3b3b3b",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-selenized-dark.sublime-theme
+++ b/base16-selenized-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#184956",
+    "layer1.tint": "#72898f",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#72898f",
+    "layer2.tint": "#2d5b69",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#72898f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#72898f",
+    "layer0.tint": "#2d5b69",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#adbcbc3f",
+    "layer0.tint": "#72898f3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cad8d9",
     "match_fg": "#dbb32d",
-    "selected_fg": "#72898f",
+    "selected_fg": "#cad8d9",
     "selected_match_fg": "#dbb32d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cad8d9",
     "match_fg": "#dbb32d",
-    "selected_fg": "#72898f",
+    "selected_fg": "#cad8d9",
     "selected_match_fg": "#dbb32d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cad8d9",
-    "match_fg": "#adbcbc",
-    "selected_fg": "#72898f",
-    "selected_match_fg": "#72898f"
+    "fg": "#72898f",
+    "match_fg": "#dbb32d",
+    "selected_fg": "#adbcbc",
+    "selected_match_fg": "#dbb32d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#72898f",
+    "layer0.tint": "#2d5b69",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cad8d9",
     "match_fg": "#dbb32d",
-    "selected_fg": "transparent",
+    "selected_fg": "#cad8d9",
     "selected_match_fg": "#dbb32d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#103c48",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2d5b69",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2d5b69",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#72898f",
+    "layer0.tint": "#2d5b69",
+    "color_scheme_tint": "#2d5b69",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-selenized-light.sublime-theme
+++ b/base16-selenized-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d5cdb6",
+    "layer0.tint": "#909995",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ece3cc1e",
+    "layer1.tint": "#909995",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#909995",
+    "layer2.tint": "#d5cdb6",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#909995",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#909995",
+    "layer0.tint": "#d5cdb6",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#53676d1e",
+    "layer0.tint": "#9099951e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#3a4d53",
+    "fg": "#53676d",
     "match_fg": "#a78300",
-    "selected_fg": "#909995",
+    "selected_fg": "#53676d",
     "selected_match_fg": "#a78300"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#3a4d53",
+    "fg": "#53676d",
     "match_fg": "#a78300",
-    "selected_fg": "#909995",
+    "selected_fg": "#53676d",
     "selected_match_fg": "#a78300"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#3a4d53",
-    "match_fg": "#53676d",
-    "selected_fg": "#909995",
-    "selected_match_fg": "#909995"
+    "fg": "#909995",
+    "match_fg": "#a78300",
+    "selected_fg": "#53676d",
+    "selected_match_fg": "#a78300"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#909995",
+    "layer0.tint": "#d5cdb6",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#3a4d53",
     "match_fg": "#a78300",
-    "selected_fg": "transparent",
+    "selected_fg": "#3a4d53",
     "selected_match_fg": "#a78300",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fbf3db",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d5cdb6",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d5cdb6",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#909995",
+    "layer0.tint": "#d5cdb6",
+    "color_scheme_tint": "#d5cdb6",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-selenized-white.sublime-theme
+++ b/base16-selenized-white.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#cdcdcd",
+    "layer0.tint": "#878787",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ebebeb1e",
+    "layer1.tint": "#878787",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#878787",
+    "layer2.tint": "#cdcdcd",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#878787",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#878787",
+    "layer0.tint": "#cdcdcd",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4747471e",
+    "layer0.tint": "#8787871e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#282828",
+    "fg": "#474747",
     "match_fg": "#af8500",
-    "selected_fg": "#878787",
+    "selected_fg": "#474747",
     "selected_match_fg": "#af8500"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#282828",
+    "fg": "#474747",
     "match_fg": "#af8500",
-    "selected_fg": "#878787",
+    "selected_fg": "#474747",
     "selected_match_fg": "#af8500"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#282828",
-    "match_fg": "#474747",
-    "selected_fg": "#878787",
-    "selected_match_fg": "#878787"
+    "fg": "#878787",
+    "match_fg": "#af8500",
+    "selected_fg": "#474747",
+    "selected_match_fg": "#af8500"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#878787",
+    "layer0.tint": "#cdcdcd",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#282828",
     "match_fg": "#af8500",
-    "selected_fg": "transparent",
+    "selected_fg": "#282828",
     "selected_match_fg": "#af8500",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#cdcdcd",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#cdcdcd",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#878787",
+    "layer0.tint": "#cdcdcd",
+    "color_scheme_tint": "#cdcdcd",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-seti.sublime-theme
+++ b/base16-seti.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#282a2b",
+    "layer1.tint": "#41535b",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#41535b",
+    "layer2.tint": "#3b758c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#41535b",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#41535b",
+    "layer0.tint": "#3b758c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d6d6d63f",
+    "layer0.tint": "#41535b3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#eeeeee",
     "match_fg": "#e6cd69",
-    "selected_fg": "#43a5d5",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e6cd69"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#eeeeee",
     "match_fg": "#e6cd69",
-    "selected_fg": "#43a5d5",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e6cd69"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#eeeeee",
-    "match_fg": "#d6d6d6",
-    "selected_fg": "#43a5d5",
-    "selected_match_fg": "#43a5d5"
+    "fg": "#43a5d5",
+    "match_fg": "#e6cd69",
+    "selected_fg": "#d6d6d6",
+    "selected_match_fg": "#e6cd69"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#41535b",
+    "layer0.tint": "#3b758c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eeeeee",
     "match_fg": "#e6cd69",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e6cd69",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#151718",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3b758c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3b758c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#41535b",
+    "layer0.tint": "#3b758c",
+    "color_scheme_tint": "#3b758c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-shades-of-purple.sublime-theme
+++ b/base16-shades-of-purple.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#43d426",
+    "layer1.tint": "#808080",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#808080",
+    "layer2.tint": "#f1d000",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#808080",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#f1d000",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c7c7c73f",
+    "layer0.tint": "#8080803f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ff77ff",
     "match_fg": "#ffe700",
-    "selected_fg": "#6871ff",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffe700"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ff77ff",
     "match_fg": "#ffe700",
-    "selected_fg": "#6871ff",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffe700"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ff77ff",
-    "match_fg": "#c7c7c7",
-    "selected_fg": "#6871ff",
-    "selected_match_fg": "#6871ff"
+    "fg": "#6871ff",
+    "match_fg": "#ffe700",
+    "selected_fg": "#c7c7c7",
+    "selected_match_fg": "#ffe700"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#808080",
+    "layer0.tint": "#f1d000",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ff77ff",
     "match_fg": "#ffe700",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffe700",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1e1e3f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#f1d000",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#f1d000",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#f1d000",
+    "color_scheme_tint": "#f1d000",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-shadesmear-dark.sublime-theme
+++ b/base16-shadesmear-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1c1c1c",
+    "layer1.tint": "#c0c0c0",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#c0c0c0",
+    "layer2.tint": "#4e4e4e",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#c0c0c0",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#4e4e4e",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#dbdbdb3f",
+    "layer0.tint": "#c0c0c03f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e4e4e4",
     "match_fg": "#307878",
-    "selected_fg": "#e4e4e4",
+    "selected_fg": "#1c1c1c",
     "selected_match_fg": "#307878"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e4e4e4",
     "match_fg": "#307878",
-    "selected_fg": "#e4e4e4",
+    "selected_fg": "#1c1c1c",
     "selected_match_fg": "#307878"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#e4e4e4",
-    "match_fg": "#dbdbdb",
-    "selected_fg": "#e4e4e4",
-    "selected_match_fg": "#e4e4e4"
+    "match_fg": "#307878",
+    "selected_fg": "#dbdbdb",
+    "selected_match_fg": "#307878"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#4e4e4e",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e4e4e4",
     "match_fg": "#307878",
-    "selected_fg": "transparent",
+    "selected_fg": "#1c1c1c",
     "selected_match_fg": "#307878",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#232323",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4e4e4e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4e4e4e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#4e4e4e",
+    "color_scheme_tint": "#4e4e4e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-shadesmear-light.sublime-theme
+++ b/base16-shadesmear-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#4e4e4e",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e4e4e41e",
+    "layer1.tint": "#4e4e4e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#4e4e4e",
+    "layer2.tint": "#c0c0c0",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#4e4e4e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#4e4e4e",
+    "layer0.tint": "#c0c0c0",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#2323231e",
+    "layer0.tint": "#4e4e4e1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#1c1c1c",
+    "fg": "#232323",
     "match_fg": "#307878",
-    "selected_fg": "#1c1c1c",
+    "selected_fg": "#232323",
     "selected_match_fg": "#307878"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#1c1c1c",
+    "fg": "#232323",
     "match_fg": "#307878",
-    "selected_fg": "#1c1c1c",
+    "selected_fg": "#232323",
     "selected_match_fg": "#307878"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#1c1c1c",
-    "match_fg": "#232323",
-    "selected_fg": "#1c1c1c",
-    "selected_match_fg": "#1c1c1c"
+    "match_fg": "#307878",
+    "selected_fg": "#232323",
+    "selected_match_fg": "#307878"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#4e4e4e",
+    "layer0.tint": "#c0c0c0",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#1c1c1c",
     "match_fg": "#307878",
-    "selected_fg": "transparent",
+    "selected_fg": "#e4e4e4",
     "selected_match_fg": "#307878",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#dbdbdb",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#c0c0c0",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#c0c0c0",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#4e4e4e",
+    "layer0.tint": "#c0c0c0",
+    "color_scheme_tint": "#c0c0c0",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-shapeshifter.sublime-theme
+++ b/base16-shapeshifter.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#ababab",
+    "layer0.tint": "#555555",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e0e0e01e",
+    "layer1.tint": "#555555",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#555555",
+    "layer2.tint": "#ababab",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#555555",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#555555",
+    "layer0.tint": "#ababab",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#1020151e",
+    "layer0.tint": "#5555551e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#040404",
+    "fg": "#102015",
     "match_fg": "#dddd13",
-    "selected_fg": "#343434",
+    "selected_fg": "#102015",
     "selected_match_fg": "#dddd13"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#040404",
+    "fg": "#102015",
     "match_fg": "#dddd13",
-    "selected_fg": "#343434",
+    "selected_fg": "#102015",
     "selected_match_fg": "#dddd13"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#040404",
-    "match_fg": "#102015",
-    "selected_fg": "#343434",
-    "selected_match_fg": "#343434"
+    "fg": "#343434",
+    "match_fg": "#dddd13",
+    "selected_fg": "#102015",
+    "selected_match_fg": "#dddd13"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#555555",
+    "layer0.tint": "#ababab",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#040404",
     "match_fg": "#dddd13",
-    "selected_fg": "transparent",
+    "selected_fg": "#000000",
     "selected_match_fg": "#dddd13",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f9f9f9",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#ababab",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#ababab",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#555555",
+    "layer0.tint": "#ababab",
+    "color_scheme_tint": "#ababab",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-silk-dark.sublime-theme
+++ b/base16-silk-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1d494e",
+    "layer1.tint": "#587073",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#587073",
+    "layer2.tint": "#2a5054",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#587073",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#587073",
+    "layer0.tint": "#2a5054",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c7dbdd3f",
+    "layer0.tint": "#5870733f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cbf2f7",
     "match_fg": "#fce380",
-    "selected_fg": "#9dc8cd",
+    "selected_fg": "#d2faff",
     "selected_match_fg": "#fce380"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cbf2f7",
     "match_fg": "#fce380",
-    "selected_fg": "#9dc8cd",
+    "selected_fg": "#d2faff",
     "selected_match_fg": "#fce380"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cbf2f7",
-    "match_fg": "#c7dbdd",
-    "selected_fg": "#9dc8cd",
-    "selected_match_fg": "#9dc8cd"
+    "fg": "#9dc8cd",
+    "match_fg": "#fce380",
+    "selected_fg": "#c7dbdd",
+    "selected_match_fg": "#fce380"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#587073",
+    "layer0.tint": "#2a5054",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cbf2f7",
     "match_fg": "#fce380",
-    "selected_fg": "transparent",
+    "selected_fg": "#d2faff",
     "selected_match_fg": "#fce380",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0e3c46",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2a5054",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2a5054",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#587073",
+    "layer0.tint": "#2a5054",
+    "color_scheme_tint": "#2a5054",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-silk-light.sublime-theme
+++ b/base16-silk-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#90b7b6",
+    "layer0.tint": "#5c787b",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#ccd4d31e",
+    "layer1.tint": "#5c787b",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5c787b",
+    "layer2.tint": "#90b7b6",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5c787b",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5c787b",
+    "layer0.tint": "#90b7b6",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3851561e",
+    "layer0.tint": "#5c787b1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#0e3c46",
+    "fg": "#385156",
     "match_fg": "#cfad25",
-    "selected_fg": "#4b5b5f",
+    "selected_fg": "#385156",
     "selected_match_fg": "#cfad25"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#0e3c46",
+    "fg": "#385156",
     "match_fg": "#cfad25",
-    "selected_fg": "#4b5b5f",
+    "selected_fg": "#385156",
     "selected_match_fg": "#cfad25"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#0e3c46",
-    "match_fg": "#385156",
-    "selected_fg": "#4b5b5f",
-    "selected_match_fg": "#4b5b5f"
+    "fg": "#4b5b5f",
+    "match_fg": "#cfad25",
+    "selected_fg": "#385156",
+    "selected_match_fg": "#cfad25"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5c787b",
+    "layer0.tint": "#90b7b6",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#0e3c46",
     "match_fg": "#cfad25",
-    "selected_fg": "transparent",
+    "selected_fg": "#d2faff",
     "selected_match_fg": "#cfad25",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#e9f1ef",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#90b7b6",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#90b7b6",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5c787b",
+    "layer0.tint": "#90b7b6",
+    "color_scheme_tint": "#90b7b6",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-snazzy.sublime-theme
+++ b/base16-snazzy.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#34353e",
+    "layer1.tint": "#78787e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#78787e",
+    "layer2.tint": "#43454f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#78787e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#78787e",
+    "layer0.tint": "#43454f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#e2e4e53f",
+    "layer0.tint": "#78787e3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#eff0eb",
     "match_fg": "#f3f99d",
-    "selected_fg": "#a5a5a9",
+    "selected_fg": "#f1f1f0",
     "selected_match_fg": "#f3f99d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#eff0eb",
     "match_fg": "#f3f99d",
-    "selected_fg": "#a5a5a9",
+    "selected_fg": "#f1f1f0",
     "selected_match_fg": "#f3f99d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#eff0eb",
-    "match_fg": "#e2e4e5",
-    "selected_fg": "#a5a5a9",
-    "selected_match_fg": "#a5a5a9"
+    "fg": "#a5a5a9",
+    "match_fg": "#f3f99d",
+    "selected_fg": "#e2e4e5",
+    "selected_match_fg": "#f3f99d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#78787e",
+    "layer0.tint": "#43454f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eff0eb",
     "match_fg": "#f3f99d",
-    "selected_fg": "transparent",
+    "selected_fg": "#f1f1f0",
     "selected_match_fg": "#f3f99d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#282a36",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#43454f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#43454f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#78787e",
+    "layer0.tint": "#43454f",
+    "color_scheme_tint": "#43454f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-solarflare-light.sublime-theme
+++ b/base16-solarflare-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#a6afb8",
+    "layer0.tint": "#85939e",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e8e9ed1e",
+    "layer1.tint": "#85939e",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#85939e",
+    "layer2.tint": "#a6afb8",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#85939e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#85939e",
+    "layer0.tint": "#a6afb8",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5868751e",
+    "layer0.tint": "#85939e1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#222e38",
+    "fg": "#586875",
     "match_fg": "#e4b51c",
-    "selected_fg": "#667581",
+    "selected_fg": "#586875",
     "selected_match_fg": "#e4b51c"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#222e38",
+    "fg": "#586875",
     "match_fg": "#e4b51c",
-    "selected_fg": "#667581",
+    "selected_fg": "#586875",
     "selected_match_fg": "#e4b51c"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#222e38",
-    "match_fg": "#586875",
-    "selected_fg": "#667581",
-    "selected_match_fg": "#667581"
+    "fg": "#667581",
+    "match_fg": "#e4b51c",
+    "selected_fg": "#586875",
+    "selected_match_fg": "#e4b51c"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#85939e",
+    "layer0.tint": "#a6afb8",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#222e38",
     "match_fg": "#e4b51c",
-    "selected_fg": "transparent",
+    "selected_fg": "#18262f",
     "selected_match_fg": "#e4b51c",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f5f7fa",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#a6afb8",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#a6afb8",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#85939e",
+    "layer0.tint": "#a6afb8",
+    "color_scheme_tint": "#a6afb8",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-solarflare.sublime-theme
+++ b/base16-solarflare.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#222e38",
+    "layer1.tint": "#667581",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#667581",
+    "layer2.tint": "#586875",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#667581",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#667581",
+    "layer0.tint": "#586875",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a6afb83f",
+    "layer0.tint": "#6675813f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e9ed",
     "match_fg": "#e4b51c",
-    "selected_fg": "#85939e",
+    "selected_fg": "#f5f7fa",
     "selected_match_fg": "#e4b51c"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e9ed",
     "match_fg": "#e4b51c",
-    "selected_fg": "#85939e",
+    "selected_fg": "#f5f7fa",
     "selected_match_fg": "#e4b51c"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e9ed",
-    "match_fg": "#a6afb8",
-    "selected_fg": "#85939e",
-    "selected_match_fg": "#85939e"
+    "fg": "#85939e",
+    "match_fg": "#e4b51c",
+    "selected_fg": "#a6afb8",
+    "selected_match_fg": "#e4b51c"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#667581",
+    "layer0.tint": "#586875",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e9ed",
     "match_fg": "#e4b51c",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5f7fa",
     "selected_match_fg": "#e4b51c",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#18262f",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#586875",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#586875",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#667581",
+    "layer0.tint": "#586875",
+    "color_scheme_tint": "#586875",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-solarized-dark.sublime-theme
+++ b/base16-solarized-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#073642",
+    "layer1.tint": "#657b83",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#657b83",
+    "layer2.tint": "#586e75",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#657b83",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#657b83",
+    "layer0.tint": "#586e75",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#93a1a13f",
+    "layer0.tint": "#657b833f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#eee8d5",
     "match_fg": "#b58900",
-    "selected_fg": "#839496",
+    "selected_fg": "#fdf6e3",
     "selected_match_fg": "#b58900"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#eee8d5",
     "match_fg": "#b58900",
-    "selected_fg": "#839496",
+    "selected_fg": "#fdf6e3",
     "selected_match_fg": "#b58900"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#eee8d5",
-    "match_fg": "#93a1a1",
-    "selected_fg": "#839496",
-    "selected_match_fg": "#839496"
+    "fg": "#839496",
+    "match_fg": "#b58900",
+    "selected_fg": "#93a1a1",
+    "selected_match_fg": "#b58900"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#657b83",
+    "layer0.tint": "#586e75",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eee8d5",
     "match_fg": "#b58900",
-    "selected_fg": "transparent",
+    "selected_fg": "#fdf6e3",
     "selected_match_fg": "#b58900",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#002b36",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#586e75",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#586e75",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#657b83",
+    "layer0.tint": "#586e75",
+    "color_scheme_tint": "#586e75",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-solarized-light.sublime-theme
+++ b/base16-solarized-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#93a1a1",
+    "layer0.tint": "#839496",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#eee8d51e",
+    "layer1.tint": "#839496",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#839496",
+    "layer2.tint": "#93a1a1",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#839496",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#839496",
+    "layer0.tint": "#93a1a1",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#586e751e",
+    "layer0.tint": "#8394961e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#073642",
+    "fg": "#586e75",
     "match_fg": "#b58900",
-    "selected_fg": "#657b83",
+    "selected_fg": "#586e75",
     "selected_match_fg": "#b58900"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#073642",
+    "fg": "#586e75",
     "match_fg": "#b58900",
-    "selected_fg": "#657b83",
+    "selected_fg": "#586e75",
     "selected_match_fg": "#b58900"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#073642",
-    "match_fg": "#586e75",
-    "selected_fg": "#657b83",
-    "selected_match_fg": "#657b83"
+    "fg": "#657b83",
+    "match_fg": "#b58900",
+    "selected_fg": "#586e75",
+    "selected_match_fg": "#b58900"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#839496",
+    "layer0.tint": "#93a1a1",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#073642",
     "match_fg": "#b58900",
-    "selected_fg": "transparent",
+    "selected_fg": "#002b36",
     "selected_match_fg": "#b58900",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fdf6e3",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#93a1a1",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#93a1a1",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#839496",
+    "layer0.tint": "#93a1a1",
+    "color_scheme_tint": "#93a1a1",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-spaceduck.sublime-theme
+++ b/base16-spaceduck.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1b1c36",
+    "layer1.tint": "#686f9a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#686f9a",
+    "layer2.tint": "#30365f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#686f9a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#686f9a",
+    "layer0.tint": "#30365f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#ecf0c13f",
+    "layer0.tint": "#686f9a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c1c3cc",
     "match_fg": "#f2ce00",
-    "selected_fg": "#818596",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f2ce00"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c1c3cc",
     "match_fg": "#f2ce00",
-    "selected_fg": "#818596",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f2ce00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c1c3cc",
-    "match_fg": "#ecf0c1",
-    "selected_fg": "#818596",
-    "selected_match_fg": "#818596"
+    "fg": "#818596",
+    "match_fg": "#f2ce00",
+    "selected_fg": "#ecf0c1",
+    "selected_match_fg": "#f2ce00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#686f9a",
+    "layer0.tint": "#30365f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c1c3cc",
     "match_fg": "#f2ce00",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f2ce00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#16172d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#30365f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#30365f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#686f9a",
+    "layer0.tint": "#30365f",
+    "color_scheme_tint": "#30365f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-spacemacs.sublime-theme
+++ b/base16-spacemacs.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#282828",
+    "layer1.tint": "#585858",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#585858",
+    "layer2.tint": "#444155",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#585858",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#585858",
+    "layer0.tint": "#444155",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a3a3a33f",
+    "layer0.tint": "#5858583f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e8e8",
     "match_fg": "#b1951d",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#b1951d"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e8e8",
     "match_fg": "#b1951d",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#b1951d"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e8e8",
-    "match_fg": "#a3a3a3",
-    "selected_fg": "#b8b8b8",
-    "selected_match_fg": "#b8b8b8"
+    "fg": "#b8b8b8",
+    "match_fg": "#b1951d",
+    "selected_fg": "#a3a3a3",
+    "selected_match_fg": "#b1951d"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#585858",
+    "layer0.tint": "#444155",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e8e8",
     "match_fg": "#b1951d",
-    "selected_fg": "transparent",
+    "selected_fg": "#f8f8f8",
     "selected_match_fg": "#b1951d",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1f2022",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#444155",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#444155",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#585858",
+    "layer0.tint": "#444155",
+    "color_scheme_tint": "#444155",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-sparky.sublime-theme
+++ b/base16-sparky.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#00313c",
+    "layer1.tint": "#003b49",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#003b49",
+    "layer2.tint": "#003c46",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#003b49",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#003b49",
+    "layer0.tint": "#003c46",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#f4f5f03f",
+    "layer0.tint": "#003b493f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f5f5f1",
     "match_fg": "#fbdd40",
-    "selected_fg": "#00778b",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbdd40"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f5f5f1",
     "match_fg": "#fbdd40",
-    "selected_fg": "#00778b",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbdd40"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f5f5f1",
-    "match_fg": "#f4f5f0",
-    "selected_fg": "#00778b",
-    "selected_match_fg": "#00778b"
+    "fg": "#00778b",
+    "match_fg": "#fbdd40",
+    "selected_fg": "#f4f5f0",
+    "selected_match_fg": "#fbdd40"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#003b49",
+    "layer0.tint": "#003c46",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f5f5f1",
     "match_fg": "#fbdd40",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#fbdd40",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#072b31",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#003c46",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#003c46",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#003b49",
+    "layer0.tint": "#003c46",
+    "color_scheme_tint": "#003c46",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-standardized-dark.sublime-theme
+++ b/base16-standardized-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#303030",
+    "layer1.tint": "#898989",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#898989",
+    "layer2.tint": "#555555",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#898989",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#898989",
+    "layer0.tint": "#555555",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c0c0c03f",
+    "layer0.tint": "#8989893f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#e1b31a",
-    "selected_fg": "#898989",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e1b31a"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#e1b31a",
-    "selected_fg": "#898989",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e1b31a"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#c0c0c0",
-    "selected_fg": "#898989",
-    "selected_match_fg": "#898989"
+    "fg": "#898989",
+    "match_fg": "#e1b31a",
+    "selected_fg": "#c0c0c0",
+    "selected_match_fg": "#e1b31a"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#898989",
+    "layer0.tint": "#555555",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#e1b31a",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e1b31a",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#555555",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#555555",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#898989",
+    "layer0.tint": "#555555",
+    "color_scheme_tint": "#555555",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-standardized-light.sublime-theme
+++ b/base16-standardized-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#cccccc",
+    "layer0.tint": "#767676",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#eeeeee1e",
+    "layer1.tint": "#767676",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#767676",
+    "layer2.tint": "#cccccc",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#767676",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#767676",
+    "layer0.tint": "#cccccc",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4444441e",
+    "layer0.tint": "#7676761e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#333333",
+    "fg": "#444444",
     "match_fg": "#ad8200",
-    "selected_fg": "#767676",
+    "selected_fg": "#444444",
     "selected_match_fg": "#ad8200"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#333333",
+    "fg": "#444444",
     "match_fg": "#ad8200",
-    "selected_fg": "#767676",
+    "selected_fg": "#444444",
     "selected_match_fg": "#ad8200"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#333333",
-    "match_fg": "#444444",
-    "selected_fg": "#767676",
-    "selected_match_fg": "#767676"
+    "fg": "#767676",
+    "match_fg": "#ad8200",
+    "selected_fg": "#444444",
+    "selected_match_fg": "#ad8200"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#767676",
+    "layer0.tint": "#cccccc",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#333333",
     "match_fg": "#ad8200",
-    "selected_fg": "transparent",
+    "selected_fg": "#222222",
     "selected_match_fg": "#ad8200",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#cccccc",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#cccccc",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#767676",
+    "layer0.tint": "#cccccc",
+    "color_scheme_tint": "#cccccc",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-stella.sublime-theme
+++ b/base16-stella.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#362b48",
+    "layer1.tint": "#655978",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#655978",
+    "layer2.tint": "#4d4160",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#655978",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#655978",
+    "layer0.tint": "#4d4160",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#998bad3f",
+    "layer0.tint": "#6559783f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#b4a5c8",
     "match_fg": "#c7c691",
-    "selected_fg": "#7f7192",
+    "selected_fg": "#ebdcff",
     "selected_match_fg": "#c7c691"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#b4a5c8",
     "match_fg": "#c7c691",
-    "selected_fg": "#7f7192",
+    "selected_fg": "#ebdcff",
     "selected_match_fg": "#c7c691"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#b4a5c8",
-    "match_fg": "#998bad",
-    "selected_fg": "#7f7192",
-    "selected_match_fg": "#7f7192"
+    "fg": "#7f7192",
+    "match_fg": "#c7c691",
+    "selected_fg": "#998bad",
+    "selected_match_fg": "#c7c691"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#655978",
+    "layer0.tint": "#4d4160",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b4a5c8",
     "match_fg": "#c7c691",
-    "selected_fg": "transparent",
+    "selected_fg": "#ebdcff",
     "selected_match_fg": "#c7c691",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2b213c",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4d4160",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4d4160",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#655978",
+    "layer0.tint": "#4d4160",
+    "color_scheme_tint": "#4d4160",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-still-alive.sublime-theme
+++ b/base16-still-alive.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#fff018",
+    "layer0.tint": "#f01818",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f0d8481e",
+    "layer1.tint": "#f01818",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#f01818",
+    "layer2.tint": "#fff018",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#f01818",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#f01818",
+    "layer0.tint": "#fff018",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d800001e",
+    "layer0.tint": "#f018181e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#489000",
+    "fg": "#d80000",
     "match_fg": "#426395",
-    "selected_fg": "#f00000",
+    "selected_fg": "#d80000",
     "selected_match_fg": "#426395"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#489000",
+    "fg": "#d80000",
     "match_fg": "#426395",
-    "selected_fg": "#f00000",
+    "selected_fg": "#d80000",
     "selected_match_fg": "#426395"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#489000",
-    "match_fg": "#d80000",
-    "selected_fg": "#f00000",
-    "selected_match_fg": "#f00000"
+    "fg": "#f00000",
+    "match_fg": "#426395",
+    "selected_fg": "#d80000",
+    "selected_match_fg": "#426395"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#f01818",
+    "layer0.tint": "#fff018",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#489000",
     "match_fg": "#426395",
-    "selected_fg": "transparent",
+    "selected_fg": "#30a860",
     "selected_match_fg": "#426395",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f0f0f0",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#fff018",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#fff018",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#f01818",
+    "layer0.tint": "#fff018",
+    "color_scheme_tint": "#fff018",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-summercamp.sublime-theme
+++ b/base16-summercamp.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2a261c",
+    "layer1.tint": "#504b38",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#504b38",
+    "layer2.tint": "#3a3527",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#504b38",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#504b38",
+    "layer0.tint": "#3a3527",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#736e553f",
+    "layer0.tint": "#504b383f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#bab696",
     "match_fg": "#f2ff27",
-    "selected_fg": "#5f5b45",
+    "selected_fg": "#f8f5de",
     "selected_match_fg": "#f2ff27"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#bab696",
     "match_fg": "#f2ff27",
-    "selected_fg": "#5f5b45",
+    "selected_fg": "#f8f5de",
     "selected_match_fg": "#f2ff27"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#bab696",
-    "match_fg": "#736e55",
-    "selected_fg": "#5f5b45",
-    "selected_match_fg": "#5f5b45"
+    "fg": "#5f5b45",
+    "match_fg": "#f2ff27",
+    "selected_fg": "#736e55",
+    "selected_match_fg": "#f2ff27"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#504b38",
+    "layer0.tint": "#3a3527",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#bab696",
     "match_fg": "#f2ff27",
-    "selected_fg": "transparent",
+    "selected_fg": "#f8f5de",
     "selected_match_fg": "#f2ff27",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1c1810",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3a3527",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3a3527",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#504b38",
+    "layer0.tint": "#3a3527",
+    "color_scheme_tint": "#3a3527",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-summerfruit-dark.sublime-theme
+++ b/base16-summerfruit-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#202020",
+    "layer1.tint": "#505050",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#505050",
+    "layer2.tint": "#303030",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#505050",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d0d0d03f",
+    "layer0.tint": "#5050503f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#aba800",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#aba800"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#aba800",
-    "selected_fg": "#b0b0b0",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#aba800"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#d0d0d0",
-    "selected_fg": "#b0b0b0",
-    "selected_match_fg": "#b0b0b0"
+    "fg": "#b0b0b0",
+    "match_fg": "#aba800",
+    "selected_fg": "#d0d0d0",
+    "selected_match_fg": "#aba800"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#aba800",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#aba800",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#151515",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#505050",
+    "layer0.tint": "#303030",
+    "color_scheme_tint": "#303030",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-summerfruit-light.sublime-theme
+++ b/base16-summerfruit-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d0d0d0",
+    "layer0.tint": "#b0b0b0",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e0e0e01e",
+    "layer1.tint": "#b0b0b0",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b0b0b0",
+    "layer2.tint": "#d0d0d0",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b0b0b0",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#d0d0d0",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#1010101e",
+    "layer0.tint": "#b0b0b01e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#151515",
+    "fg": "#101010",
     "match_fg": "#aba800",
-    "selected_fg": "#000000",
+    "selected_fg": "#101010",
     "selected_match_fg": "#aba800"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#151515",
+    "fg": "#101010",
     "match_fg": "#aba800",
-    "selected_fg": "#000000",
+    "selected_fg": "#101010",
     "selected_match_fg": "#aba800"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#151515",
-    "match_fg": "#101010",
-    "selected_fg": "#000000",
-    "selected_match_fg": "#000000"
+    "fg": "#000000",
+    "match_fg": "#aba800",
+    "selected_fg": "#101010",
+    "selected_match_fg": "#aba800"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#d0d0d0",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#151515",
     "match_fg": "#aba800",
-    "selected_fg": "transparent",
+    "selected_fg": "#202020",
     "selected_match_fg": "#aba800",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d0d0d0",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d0d0d0",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b0b0b0",
+    "layer0.tint": "#d0d0d0",
+    "color_scheme_tint": "#d0d0d0",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-synth-midnight-dark.sublime-theme
+++ b/base16-synth-midnight-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1a1b1c",
+    "layer1.tint": "#474849",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#474849",
+    "layer2.tint": "#28292a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#474849",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#474849",
+    "layer0.tint": "#28292a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c1c3c43f",
+    "layer0.tint": "#4748493f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cfd1d2",
     "match_fg": "#c9d364",
-    "selected_fg": "#a3a5a6",
+    "selected_fg": "#dddfe0",
     "selected_match_fg": "#c9d364"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cfd1d2",
     "match_fg": "#c9d364",
-    "selected_fg": "#a3a5a6",
+    "selected_fg": "#dddfe0",
     "selected_match_fg": "#c9d364"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cfd1d2",
-    "match_fg": "#c1c3c4",
-    "selected_fg": "#a3a5a6",
-    "selected_match_fg": "#a3a5a6"
+    "fg": "#a3a5a6",
+    "match_fg": "#c9d364",
+    "selected_fg": "#c1c3c4",
+    "selected_match_fg": "#c9d364"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#474849",
+    "layer0.tint": "#28292a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cfd1d2",
     "match_fg": "#c9d364",
-    "selected_fg": "transparent",
+    "selected_fg": "#dddfe0",
     "selected_match_fg": "#c9d364",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#050608",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#28292a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#28292a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#474849",
+    "layer0.tint": "#28292a",
+    "color_scheme_tint": "#28292a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-synth-midnight-light.sublime-theme
+++ b/base16-synth-midnight-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#c1c3c4",
+    "layer0.tint": "#a3a5a6",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#cfd1d21e",
+    "layer1.tint": "#a3a5a6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#a3a5a6",
+    "layer2.tint": "#c1c3c4",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#a3a5a6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#a3a5a6",
+    "layer0.tint": "#c1c3c4",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#28292a1e",
+    "layer0.tint": "#a3a5a61e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#1a1b1c",
+    "fg": "#28292a",
     "match_fg": "#c9d364",
-    "selected_fg": "#474849",
+    "selected_fg": "#28292a",
     "selected_match_fg": "#c9d364"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#1a1b1c",
+    "fg": "#28292a",
     "match_fg": "#c9d364",
-    "selected_fg": "#474849",
+    "selected_fg": "#28292a",
     "selected_match_fg": "#c9d364"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#1a1b1c",
-    "match_fg": "#28292a",
-    "selected_fg": "#474849",
-    "selected_match_fg": "#474849"
+    "fg": "#474849",
+    "match_fg": "#c9d364",
+    "selected_fg": "#28292a",
+    "selected_match_fg": "#c9d364"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#a3a5a6",
+    "layer0.tint": "#c1c3c4",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#1a1b1c",
     "match_fg": "#c9d364",
-    "selected_fg": "transparent",
+    "selected_fg": "#050608",
     "selected_match_fg": "#c9d364",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#dddfe0",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#c1c3c4",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#c1c3c4",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#a3a5a6",
+    "layer0.tint": "#c1c3c4",
+    "color_scheme_tint": "#c1c3c4",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tango.sublime-theme
+++ b/base16-tango.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#8ae234",
+    "layer1.tint": "#555753",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#555753",
+    "layer2.tint": "#fce94f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#555753",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#555753",
+    "layer0.tint": "#fce94f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d3d7cf3f",
+    "layer0.tint": "#5557533f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#ad7fa8",
     "match_fg": "#c4a000",
-    "selected_fg": "#729fcf",
+    "selected_fg": "#eeeeec",
     "selected_match_fg": "#c4a000"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#ad7fa8",
     "match_fg": "#c4a000",
-    "selected_fg": "#729fcf",
+    "selected_fg": "#eeeeec",
     "selected_match_fg": "#c4a000"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#ad7fa8",
-    "match_fg": "#d3d7cf",
-    "selected_fg": "#729fcf",
-    "selected_match_fg": "#729fcf"
+    "fg": "#729fcf",
+    "match_fg": "#c4a000",
+    "selected_fg": "#d3d7cf",
+    "selected_match_fg": "#c4a000"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#555753",
+    "layer0.tint": "#fce94f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ad7fa8",
     "match_fg": "#c4a000",
-    "selected_fg": "transparent",
+    "selected_fg": "#eeeeec",
     "selected_match_fg": "#c4a000",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2e3436",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#fce94f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#fce94f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#555753",
+    "layer0.tint": "#fce94f",
+    "color_scheme_tint": "#fce94f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tarot.sublime-theme
+++ b/base16-tarot.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2a153c",
+    "layer1.tint": "#74316b",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#74316b",
+    "layer2.tint": "#4b2054",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#74316b",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#74316b",
+    "layer0.tint": "#4b2054",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#aa556f3f",
+    "layer0.tint": "#74316b3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c4686d",
     "match_fg": "#ff6565",
-    "selected_fg": "#8c406f",
+    "selected_fg": "#dc8f7c",
     "selected_match_fg": "#ff6565"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c4686d",
     "match_fg": "#ff6565",
-    "selected_fg": "#8c406f",
+    "selected_fg": "#dc8f7c",
     "selected_match_fg": "#ff6565"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c4686d",
-    "match_fg": "#aa556f",
-    "selected_fg": "#8c406f",
-    "selected_match_fg": "#8c406f"
+    "fg": "#8c406f",
+    "match_fg": "#ff6565",
+    "selected_fg": "#aa556f",
+    "selected_match_fg": "#ff6565"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#74316b",
+    "layer0.tint": "#4b2054",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c4686d",
     "match_fg": "#ff6565",
-    "selected_fg": "transparent",
+    "selected_fg": "#dc8f7c",
     "selected_match_fg": "#ff6565",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0e091d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4b2054",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4b2054",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#74316b",
+    "layer0.tint": "#4b2054",
+    "color_scheme_tint": "#4b2054",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tender.sublime-theme
+++ b/base16-tender.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#383838",
+    "layer1.tint": "#4c4c4c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#4c4c4c",
+    "layer2.tint": "#484848",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#4c4c4c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#4c4c4c",
+    "layer0.tint": "#484848",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#eeeeee3f",
+    "layer0.tint": "#4c4c4c3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e8e8e8",
     "match_fg": "#ffc24b",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#feffff",
     "selected_match_fg": "#ffc24b"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e8e8e8",
     "match_fg": "#ffc24b",
-    "selected_fg": "#b8b8b8",
+    "selected_fg": "#feffff",
     "selected_match_fg": "#ffc24b"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e8e8e8",
-    "match_fg": "#eeeeee",
-    "selected_fg": "#b8b8b8",
-    "selected_match_fg": "#b8b8b8"
+    "fg": "#b8b8b8",
+    "match_fg": "#ffc24b",
+    "selected_fg": "#eeeeee",
+    "selected_match_fg": "#ffc24b"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#4c4c4c",
+    "layer0.tint": "#484848",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e8e8e8",
     "match_fg": "#ffc24b",
-    "selected_fg": "transparent",
+    "selected_fg": "#feffff",
     "selected_match_fg": "#ffc24b",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#282828",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#484848",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#484848",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#4c4c4c",
+    "layer0.tint": "#484848",
+    "color_scheme_tint": "#484848",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-terracotta-dark.sublime-theme
+++ b/base16-terracotta-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#362b27",
+    "layer1.tint": "#594740",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#594740",
+    "layer2.tint": "#473933",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#594740",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#594740",
+    "layer0.tint": "#473933",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b8a59d3f",
+    "layer0.tint": "#5947403f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cabbb5",
     "match_fg": "#ffc37a",
-    "selected_fg": "#a78e84",
+    "selected_fg": "#dcd2ce",
     "selected_match_fg": "#ffc37a"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cabbb5",
     "match_fg": "#ffc37a",
-    "selected_fg": "#a78e84",
+    "selected_fg": "#dcd2ce",
     "selected_match_fg": "#ffc37a"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cabbb5",
-    "match_fg": "#b8a59d",
-    "selected_fg": "#a78e84",
-    "selected_match_fg": "#a78e84"
+    "fg": "#a78e84",
+    "match_fg": "#ffc37a",
+    "selected_fg": "#b8a59d",
+    "selected_match_fg": "#ffc37a"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#594740",
+    "layer0.tint": "#473933",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cabbb5",
     "match_fg": "#ffc37a",
-    "selected_fg": "transparent",
+    "selected_fg": "#dcd2ce",
     "selected_match_fg": "#ffc37a",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#241d1a",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#473933",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#473933",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#594740",
+    "layer0.tint": "#473933",
+    "color_scheme_tint": "#473933",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-terracotta.sublime-theme
+++ b/base16-terracotta.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d0c1bb",
+    "layer0.tint": "#c0aca4",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#dfd6d11e",
+    "layer1.tint": "#c0aca4",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#c0aca4",
+    "layer2.tint": "#d0c1bb",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#c0aca4",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#c0aca4",
+    "layer0.tint": "#d0c1bb",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4737311e",
+    "layer0.tint": "#c0aca41e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#352a25",
+    "fg": "#473731",
     "match_fg": "#ce943e",
-    "selected_fg": "#59453d",
+    "selected_fg": "#473731",
     "selected_match_fg": "#ce943e"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#352a25",
+    "fg": "#473731",
     "match_fg": "#ce943e",
-    "selected_fg": "#59453d",
+    "selected_fg": "#473731",
     "selected_match_fg": "#ce943e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#352a25",
-    "match_fg": "#473731",
-    "selected_fg": "#59453d",
-    "selected_match_fg": "#59453d"
+    "fg": "#59453d",
+    "match_fg": "#ce943e",
+    "selected_fg": "#473731",
+    "selected_match_fg": "#ce943e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#c0aca4",
+    "layer0.tint": "#d0c1bb",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#352a25",
     "match_fg": "#ce943e",
-    "selected_fg": "transparent",
+    "selected_fg": "#241c19",
     "selected_match_fg": "#ce943e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#efeae8",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d0c1bb",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d0c1bb",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#c0aca4",
+    "layer0.tint": "#d0c1bb",
+    "color_scheme_tint": "#d0c1bb",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-city-dark.sublime-theme
+++ b/base16-tokyo-city-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1d252c",
+    "layer1.tint": "#526270",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#526270",
+    "layer2.tint": "#28323a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#526270",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#526270",
+    "layer0.tint": "#28323a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d8e2ec3f",
+    "layer0.tint": "#5262703f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f6f6f8",
     "match_fg": "#b7c5d3",
-    "selected_fg": "#b7c5d3",
+    "selected_fg": "#fbfbfd",
     "selected_match_fg": "#b7c5d3"
   },
   {
@@ -636,14 +630,14 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f6f6f8",
     "match_fg": "#b7c5d3",
-    "selected_fg": "#b7c5d3",
+    "selected_fg": "#fbfbfd",
     "selected_match_fg": "#b7c5d3"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f6f6f8",
-    "match_fg": "#d8e2ec",
-    "selected_fg": "#b7c5d3",
+    "fg": "#b7c5d3",
+    "match_fg": "#b7c5d3",
+    "selected_fg": "#d8e2ec",
     "selected_match_fg": "#b7c5d3"
   },
   {
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#526270",
+    "layer0.tint": "#28323a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f6f6f8",
     "match_fg": "#b7c5d3",
-    "selected_fg": "transparent",
+    "selected_fg": "#fbfbfd",
     "selected_match_fg": "#b7c5d3",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#171d23",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#28323a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#28323a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#526270",
+    "layer0.tint": "#28323a",
+    "color_scheme_tint": "#28323a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-city-light.sublime-theme
+++ b/base16-tokyo-city-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#edeff6",
+    "layer0.tint": "#9699a3",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f6f6f81e",
+    "layer1.tint": "#9699a3",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9699a3",
+    "layer2.tint": "#edeff6",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9699a3",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#edeff6",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#343b591e",
+    "layer0.tint": "#9699a31e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,24 +620,24 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#1d252c",
+    "fg": "#343b59",
     "match_fg": "#4c505e",
-    "selected_fg": "#4c505e",
+    "selected_fg": "#343b59",
     "selected_match_fg": "#4c505e"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#1d252c",
+    "fg": "#343b59",
     "match_fg": "#4c505e",
-    "selected_fg": "#4c505e",
+    "selected_fg": "#343b59",
     "selected_match_fg": "#4c505e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#1d252c",
-    "match_fg": "#343b59",
-    "selected_fg": "#4c505e",
+    "fg": "#4c505e",
+    "match_fg": "#4c505e",
+    "selected_fg": "#343b59",
     "selected_match_fg": "#4c505e"
   },
   {
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#edeff6",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#1d252c",
     "match_fg": "#4c505e",
-    "selected_fg": "transparent",
+    "selected_fg": "#171d23",
     "selected_match_fg": "#4c505e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fbfbfd",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#edeff6",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#edeff6",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#edeff6",
+    "color_scheme_tint": "#edeff6",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-city-terminal-dark.sublime-theme
+++ b/base16-tokyo-city-terminal-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1d252c",
+    "layer1.tint": "#526270",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#526270",
+    "layer2.tint": "#28323a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#526270",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#526270",
+    "layer0.tint": "#28323a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d8e2ec3f",
+    "layer0.tint": "#5262703f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#f6f6f8",
     "match_fg": "#ebbf83",
-    "selected_fg": "#b7c5d3",
+    "selected_fg": "#fbfbfd",
     "selected_match_fg": "#ebbf83"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#f6f6f8",
     "match_fg": "#ebbf83",
-    "selected_fg": "#b7c5d3",
+    "selected_fg": "#fbfbfd",
     "selected_match_fg": "#ebbf83"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#f6f6f8",
-    "match_fg": "#d8e2ec",
-    "selected_fg": "#b7c5d3",
-    "selected_match_fg": "#b7c5d3"
+    "fg": "#b7c5d3",
+    "match_fg": "#ebbf83",
+    "selected_fg": "#d8e2ec",
+    "selected_match_fg": "#ebbf83"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#526270",
+    "layer0.tint": "#28323a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f6f6f8",
     "match_fg": "#ebbf83",
-    "selected_fg": "transparent",
+    "selected_fg": "#fbfbfd",
     "selected_match_fg": "#ebbf83",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#171d23",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#28323a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#28323a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#526270",
+    "layer0.tint": "#28323a",
+    "color_scheme_tint": "#28323a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-city-terminal-light.sublime-theme
+++ b/base16-tokyo-city-terminal-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d8e2ec",
+    "layer0.tint": "#b7c5d3",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#f6f6f81e",
+    "layer1.tint": "#b7c5d3",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b7c5d3",
+    "layer2.tint": "#d8e2ec",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b7c5d3",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b7c5d3",
+    "layer0.tint": "#d8e2ec",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#28323a1e",
+    "layer0.tint": "#b7c5d31e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#1d252c",
+    "fg": "#28323a",
     "match_fg": "#8f5e15",
-    "selected_fg": "#526270",
+    "selected_fg": "#28323a",
     "selected_match_fg": "#8f5e15"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#1d252c",
+    "fg": "#28323a",
     "match_fg": "#8f5e15",
-    "selected_fg": "#526270",
+    "selected_fg": "#28323a",
     "selected_match_fg": "#8f5e15"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#1d252c",
-    "match_fg": "#28323a",
-    "selected_fg": "#526270",
-    "selected_match_fg": "#526270"
+    "fg": "#526270",
+    "match_fg": "#8f5e15",
+    "selected_fg": "#28323a",
+    "selected_match_fg": "#8f5e15"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b7c5d3",
+    "layer0.tint": "#d8e2ec",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#1d252c",
     "match_fg": "#8f5e15",
-    "selected_fg": "transparent",
+    "selected_fg": "#171d23",
     "selected_match_fg": "#8f5e15",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fbfbfd",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d8e2ec",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d8e2ec",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b7c5d3",
+    "layer0.tint": "#d8e2ec",
+    "color_scheme_tint": "#d8e2ec",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-night-dark.sublime-theme
+++ b/base16-tokyo-night-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#16161e",
+    "layer1.tint": "#444b6a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#444b6a",
+    "layer2.tint": "#2f3549",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#444b6a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#2f3549",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a9b1d63f",
+    "layer0.tint": "#444b6a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cbccd1",
     "match_fg": "#0db9d7",
-    "selected_fg": "#787c99",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#0db9d7"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cbccd1",
     "match_fg": "#0db9d7",
-    "selected_fg": "#787c99",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#0db9d7"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cbccd1",
-    "match_fg": "#a9b1d6",
-    "selected_fg": "#787c99",
-    "selected_match_fg": "#787c99"
+    "fg": "#787c99",
+    "match_fg": "#0db9d7",
+    "selected_fg": "#a9b1d6",
+    "selected_match_fg": "#0db9d7"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#2f3549",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cbccd1",
     "match_fg": "#0db9d7",
-    "selected_fg": "transparent",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#0db9d7",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1a1b26",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2f3549",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2f3549",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#2f3549",
+    "color_scheme_tint": "#2f3549",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-night-light.sublime-theme
+++ b/base16-tokyo-night-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#dfe0e5",
+    "layer0.tint": "#9699a3",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#cbccd11e",
+    "layer1.tint": "#9699a3",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9699a3",
+    "layer2.tint": "#dfe0e5",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9699a3",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#dfe0e5",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#343b591e",
+    "layer0.tint": "#9699a31e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#1a1b26",
+    "fg": "#343b59",
     "match_fg": "#166775",
-    "selected_fg": "#4c505e",
+    "selected_fg": "#343b59",
     "selected_match_fg": "#166775"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#1a1b26",
+    "fg": "#343b59",
     "match_fg": "#166775",
-    "selected_fg": "#4c505e",
+    "selected_fg": "#343b59",
     "selected_match_fg": "#166775"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#1a1b26",
-    "match_fg": "#343b59",
-    "selected_fg": "#4c505e",
-    "selected_match_fg": "#4c505e"
+    "fg": "#4c505e",
+    "match_fg": "#166775",
+    "selected_fg": "#343b59",
+    "selected_match_fg": "#166775"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#dfe0e5",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#1a1b26",
     "match_fg": "#166775",
-    "selected_fg": "transparent",
+    "selected_fg": "#1a1b26",
     "selected_match_fg": "#166775",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#d5d6db",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#dfe0e5",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#dfe0e5",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#dfe0e5",
+    "color_scheme_tint": "#dfe0e5",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-night-moon.sublime-theme
+++ b/base16-tokyo-night-moon.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1e2030",
+    "layer1.tint": "#636da6",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#636da6",
+    "layer2.tint": "#2d3f76",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#636da6",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#636da6",
+    "layer0.tint": "#2d3f76",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#3b42613f",
+    "layer0.tint": "#636da63f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#828bb8",
     "match_fg": "#ffc777",
-    "selected_fg": "#828bb8",
+    "selected_fg": "#c8d3f5",
     "selected_match_fg": "#ffc777"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#828bb8",
     "match_fg": "#ffc777",
-    "selected_fg": "#828bb8",
+    "selected_fg": "#c8d3f5",
     "selected_match_fg": "#ffc777"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#828bb8",
-    "match_fg": "#3b4261",
-    "selected_fg": "#828bb8",
-    "selected_match_fg": "#828bb8"
+    "match_fg": "#ffc777",
+    "selected_fg": "#3b4261",
+    "selected_match_fg": "#ffc777"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#636da6",
+    "layer0.tint": "#2d3f76",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#828bb8",
     "match_fg": "#ffc777",
-    "selected_fg": "transparent",
+    "selected_fg": "#c8d3f5",
     "selected_match_fg": "#ffc777",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#222436",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2d3f76",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2d3f76",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#636da6",
+    "layer0.tint": "#2d3f76",
+    "color_scheme_tint": "#2d3f76",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-night-storm.sublime-theme
+++ b/base16-tokyo-night-storm.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#16161e",
+    "layer1.tint": "#444b6a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#444b6a",
+    "layer2.tint": "#343a52",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#444b6a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#343a52",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a9b1d63f",
+    "layer0.tint": "#444b6a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cbccd1",
     "match_fg": "#0db9d7",
-    "selected_fg": "#787c99",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#0db9d7"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cbccd1",
     "match_fg": "#0db9d7",
-    "selected_fg": "#787c99",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#0db9d7"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cbccd1",
-    "match_fg": "#a9b1d6",
-    "selected_fg": "#787c99",
-    "selected_match_fg": "#787c99"
+    "fg": "#787c99",
+    "match_fg": "#0db9d7",
+    "selected_fg": "#a9b1d6",
+    "selected_match_fg": "#0db9d7"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#343a52",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cbccd1",
     "match_fg": "#0db9d7",
-    "selected_fg": "transparent",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#0db9d7",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#24283b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#343a52",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#343a52",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#343a52",
+    "color_scheme_tint": "#343a52",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-night-terminal-dark.sublime-theme
+++ b/base16-tokyo-night-terminal-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1a1b26",
+    "layer1.tint": "#444b6a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#444b6a",
+    "layer2.tint": "#2f3549",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#444b6a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#2f3549",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#787c993f",
+    "layer0.tint": "#444b6a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cbccd1",
     "match_fg": "#e0af68",
-    "selected_fg": "#787c99",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#e0af68"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cbccd1",
     "match_fg": "#e0af68",
-    "selected_fg": "#787c99",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#e0af68"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cbccd1",
-    "match_fg": "#787c99",
+    "fg": "#787c99",
+    "match_fg": "#e0af68",
     "selected_fg": "#787c99",
-    "selected_match_fg": "#787c99"
+    "selected_match_fg": "#e0af68"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#2f3549",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cbccd1",
     "match_fg": "#e0af68",
-    "selected_fg": "transparent",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#e0af68",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#16161e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2f3549",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2f3549",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#2f3549",
+    "color_scheme_tint": "#2f3549",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-night-terminal-light.sublime-theme
+++ b/base16-tokyo-night-terminal-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#dfe0e5",
+    "layer0.tint": "#9699a3",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#cbccd11e",
+    "layer1.tint": "#9699a3",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9699a3",
+    "layer2.tint": "#dfe0e5",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9699a3",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#dfe0e5",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4c505e1e",
+    "layer0.tint": "#9699a31e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,7 +620,7 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#1a1b26",
+    "fg": "#4c505e",
     "match_fg": "#8f5e15",
     "selected_fg": "#4c505e",
     "selected_match_fg": "#8f5e15"
@@ -634,17 +628,17 @@
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#1a1b26",
+    "fg": "#4c505e",
     "match_fg": "#8f5e15",
     "selected_fg": "#4c505e",
     "selected_match_fg": "#8f5e15"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#1a1b26",
-    "match_fg": "#4c505e",
+    "fg": "#4c505e",
+    "match_fg": "#8f5e15",
     "selected_fg": "#4c505e",
-    "selected_match_fg": "#4c505e"
+    "selected_match_fg": "#8f5e15"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#dfe0e5",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#1a1b26",
     "match_fg": "#8f5e15",
-    "selected_fg": "transparent",
+    "selected_fg": "#1a1b26",
     "selected_match_fg": "#8f5e15",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#d5d6db",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#dfe0e5",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#dfe0e5",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9699a3",
+    "layer0.tint": "#dfe0e5",
+    "color_scheme_tint": "#dfe0e5",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyo-night-terminal-storm.sublime-theme
+++ b/base16-tokyo-night-terminal-storm.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1a1b26",
+    "layer1.tint": "#444b6a",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#444b6a",
+    "layer2.tint": "#343a52",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#444b6a",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#343a52",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#787c993f",
+    "layer0.tint": "#444b6a3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#cbccd1",
     "match_fg": "#e0af68",
-    "selected_fg": "#787c99",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#e0af68"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#cbccd1",
     "match_fg": "#e0af68",
-    "selected_fg": "#787c99",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#e0af68"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#cbccd1",
-    "match_fg": "#787c99",
+    "fg": "#787c99",
+    "match_fg": "#e0af68",
     "selected_fg": "#787c99",
-    "selected_match_fg": "#787c99"
+    "selected_match_fg": "#e0af68"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#343a52",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cbccd1",
     "match_fg": "#e0af68",
-    "selected_fg": "transparent",
+    "selected_fg": "#d5d6db",
     "selected_match_fg": "#e0af68",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#24283b",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#343a52",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#343a52",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#444b6a",
+    "layer0.tint": "#343a52",
+    "color_scheme_tint": "#343a52",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyodark-terminal.sublime-theme
+++ b/base16-tokyodark-terminal.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1a1b2a",
+    "layer1.tint": "#282c34",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#282c34",
+    "layer2.tint": "#212234",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#282c34",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#282c34",
+    "layer0.tint": "#212234",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a0a8cd3f",
+    "layer0.tint": "#282c343f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#a0a8cd",
     "match_fg": "#d7a65f",
-    "selected_fg": "#4a5057",
+    "selected_fg": "#a0a8cd",
     "selected_match_fg": "#d7a65f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#a0a8cd",
     "match_fg": "#d7a65f",
-    "selected_fg": "#4a5057",
+    "selected_fg": "#a0a8cd",
     "selected_match_fg": "#d7a65f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#a0a8cd",
-    "match_fg": "#a0a8cd",
-    "selected_fg": "#4a5057",
-    "selected_match_fg": "#4a5057"
+    "fg": "#4a5057",
+    "match_fg": "#d7a65f",
+    "selected_fg": "#a0a8cd",
+    "selected_match_fg": "#d7a65f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#282c34",
+    "layer0.tint": "#212234",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#a0a8cd",
     "match_fg": "#d7a65f",
-    "selected_fg": "transparent",
+    "selected_fg": "#a0a8cd",
     "selected_match_fg": "#d7a65f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#11121d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#212234",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#212234",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#282c34",
+    "layer0.tint": "#212234",
+    "color_scheme_tint": "#212234",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tokyodark.sublime-theme
+++ b/base16-tokyodark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#151621",
+    "layer1.tint": "#393a45",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#393a45",
+    "layer2.tint": "#43444f",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#393a45",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#393a45",
+    "layer0.tint": "#43444f",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#abb2bf3f",
+    "layer0.tint": "#393a453f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#555661",
     "match_fg": "#7199ee",
-    "selected_fg": "#1b1c27",
+    "selected_fg": "#2c2d38",
     "selected_match_fg": "#7199ee"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#555661",
     "match_fg": "#7199ee",
-    "selected_fg": "#1b1c27",
+    "selected_fg": "#2c2d38",
     "selected_match_fg": "#7199ee"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#555661",
-    "match_fg": "#abb2bf",
-    "selected_fg": "#1b1c27",
-    "selected_match_fg": "#1b1c27"
+    "fg": "#1b1c27",
+    "match_fg": "#7199ee",
+    "selected_fg": "#abb2bf",
+    "selected_match_fg": "#7199ee"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#393a45",
+    "layer0.tint": "#43444f",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#555661",
     "match_fg": "#7199ee",
-    "selected_fg": "transparent",
+    "selected_fg": "#2c2d38",
     "selected_match_fg": "#7199ee",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#11121d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#43444f",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#43444f",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#393a45",
+    "layer0.tint": "#43444f",
+    "color_scheme_tint": "#43444f",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tomorrow-night-eighties.sublime-theme
+++ b/base16-tomorrow-night-eighties.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#393939",
+    "layer1.tint": "#999999",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#999999",
+    "layer2.tint": "#515151",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#999999",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#999999",
+    "layer0.tint": "#515151",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cccccc3f",
+    "layer0.tint": "#9999993f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#ffcc66",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcc66"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#ffcc66",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcc66"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#cccccc",
-    "selected_fg": "#b4b7b4",
-    "selected_match_fg": "#b4b7b4"
+    "fg": "#b4b7b4",
+    "match_fg": "#ffcc66",
+    "selected_fg": "#cccccc",
+    "selected_match_fg": "#ffcc66"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#999999",
+    "layer0.tint": "#515151",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#ffcc66",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffcc66",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2d2d2d",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#515151",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#515151",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#999999",
+    "layer0.tint": "#515151",
+    "color_scheme_tint": "#515151",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tomorrow-night.sublime-theme
+++ b/base16-tomorrow-night.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#282a2e",
+    "layer1.tint": "#969896",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#969896",
+    "layer2.tint": "#373b41",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#969896",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#969896",
+    "layer0.tint": "#373b41",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c5c8c63f",
+    "layer0.tint": "#9698963f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#f0c674",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f0c674"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#f0c674",
-    "selected_fg": "#b4b7b4",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f0c674"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#c5c8c6",
-    "selected_fg": "#b4b7b4",
-    "selected_match_fg": "#b4b7b4"
+    "fg": "#b4b7b4",
+    "match_fg": "#f0c674",
+    "selected_fg": "#c5c8c6",
+    "selected_match_fg": "#f0c674"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#969896",
+    "layer0.tint": "#373b41",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#f0c674",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f0c674",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1d1f21",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#373b41",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#373b41",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#969896",
+    "layer0.tint": "#373b41",
+    "color_scheme_tint": "#373b41",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tomorrow.sublime-theme
+++ b/base16-tomorrow.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d6d6d6",
+    "layer0.tint": "#8e908c",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e0e0e01e",
+    "layer1.tint": "#8e908c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#8e908c",
+    "layer2.tint": "#d6d6d6",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#8e908c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#8e908c",
+    "layer0.tint": "#d6d6d6",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#4d4d4c1e",
+    "layer0.tint": "#8e908c1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#282a2e",
+    "fg": "#4d4d4c",
     "match_fg": "#eab700",
-    "selected_fg": "#969896",
+    "selected_fg": "#4d4d4c",
     "selected_match_fg": "#eab700"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#282a2e",
+    "fg": "#4d4d4c",
     "match_fg": "#eab700",
-    "selected_fg": "#969896",
+    "selected_fg": "#4d4d4c",
     "selected_match_fg": "#eab700"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#282a2e",
-    "match_fg": "#4d4d4c",
-    "selected_fg": "#969896",
-    "selected_match_fg": "#969896"
+    "fg": "#969896",
+    "match_fg": "#eab700",
+    "selected_fg": "#4d4d4c",
+    "selected_match_fg": "#eab700"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#8e908c",
+    "layer0.tint": "#d6d6d6",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#282a2e",
     "match_fg": "#eab700",
-    "selected_fg": "transparent",
+    "selected_fg": "#1d1f21",
     "selected_match_fg": "#eab700",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d6d6d6",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d6d6d6",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#8e908c",
+    "layer0.tint": "#d6d6d6",
+    "color_scheme_tint": "#d6d6d6",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-tube.sublime-theme
+++ b/base16-tube.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1c3f95",
+    "layer1.tint": "#737171",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#737171",
+    "layer2.tint": "#5a5758",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#737171",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#737171",
+    "layer0.tint": "#5a5758",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#d9d8d83f",
+    "layer0.tint": "#7371713f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e7e7e8",
     "match_fg": "#ffd204",
-    "selected_fg": "#959ca1",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffd204"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e7e7e8",
     "match_fg": "#ffd204",
-    "selected_fg": "#959ca1",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffd204"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e7e7e8",
-    "match_fg": "#d9d8d8",
-    "selected_fg": "#959ca1",
-    "selected_match_fg": "#959ca1"
+    "fg": "#959ca1",
+    "match_fg": "#ffd204",
+    "selected_fg": "#d9d8d8",
+    "selected_match_fg": "#ffd204"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#737171",
+    "layer0.tint": "#5a5758",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e7e7e8",
     "match_fg": "#ffd204",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffd204",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#231f20",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#5a5758",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#5a5758",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#737171",
+    "layer0.tint": "#5a5758",
+    "color_scheme_tint": "#5a5758",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-twilight.sublime-theme
+++ b/base16-twilight.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#323537",
+    "layer1.tint": "#5f5a60",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#5f5a60",
+    "layer2.tint": "#464b50",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#5f5a60",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#5f5a60",
+    "layer0.tint": "#464b50",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a7a7a73f",
+    "layer0.tint": "#5f5a603f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c3c3c3",
     "match_fg": "#f9ee98",
-    "selected_fg": "#838184",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f9ee98"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c3c3c3",
     "match_fg": "#f9ee98",
-    "selected_fg": "#838184",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f9ee98"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c3c3c3",
-    "match_fg": "#a7a7a7",
-    "selected_fg": "#838184",
-    "selected_match_fg": "#838184"
+    "fg": "#838184",
+    "match_fg": "#f9ee98",
+    "selected_fg": "#a7a7a7",
+    "selected_match_fg": "#f9ee98"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#5f5a60",
+    "layer0.tint": "#464b50",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c3c3c3",
     "match_fg": "#f9ee98",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f9ee98",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#1e1e1e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#464b50",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#464b50",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#5f5a60",
+    "layer0.tint": "#464b50",
+    "color_scheme_tint": "#464b50",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-unikitty-dark.sublime-theme
+++ b/base16-unikitty-dark.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#4a464d",
+    "layer1.tint": "#838085",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#838085",
+    "layer2.tint": "#666369",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#838085",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#838085",
+    "layer0.tint": "#666369",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#bcbabe3f",
+    "layer0.tint": "#8380853f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d8d7da",
     "match_fg": "#dc8a0e",
-    "selected_fg": "#9f9da2",
+    "selected_fg": "#f5f4f7",
     "selected_match_fg": "#dc8a0e"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d8d7da",
     "match_fg": "#dc8a0e",
-    "selected_fg": "#9f9da2",
+    "selected_fg": "#f5f4f7",
     "selected_match_fg": "#dc8a0e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d8d7da",
-    "match_fg": "#bcbabe",
-    "selected_fg": "#9f9da2",
-    "selected_match_fg": "#9f9da2"
+    "fg": "#9f9da2",
+    "match_fg": "#dc8a0e",
+    "selected_fg": "#bcbabe",
+    "selected_match_fg": "#dc8a0e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#838085",
+    "layer0.tint": "#666369",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d8d7da",
     "match_fg": "#dc8a0e",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5f4f7",
     "selected_match_fg": "#dc8a0e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2e2a31",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#666369",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#666369",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#838085",
+    "layer0.tint": "#666369",
+    "color_scheme_tint": "#666369",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-unikitty-light.sublime-theme
+++ b/base16-unikitty-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#c4c3c5",
+    "layer0.tint": "#a7a5a8",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e1e1e21e",
+    "layer1.tint": "#a7a5a8",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#a7a5a8",
+    "layer2.tint": "#c4c3c5",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#a7a5a8",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#a7a5a8",
+    "layer0.tint": "#c4c3c5",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#6c696e1e",
+    "layer0.tint": "#a7a5a81e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#4f4b51",
+    "fg": "#6c696e",
     "match_fg": "#dc8a0e",
-    "selected_fg": "#89878b",
+    "selected_fg": "#6c696e",
     "selected_match_fg": "#dc8a0e"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#4f4b51",
+    "fg": "#6c696e",
     "match_fg": "#dc8a0e",
-    "selected_fg": "#89878b",
+    "selected_fg": "#6c696e",
     "selected_match_fg": "#dc8a0e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#4f4b51",
-    "match_fg": "#6c696e",
-    "selected_fg": "#89878b",
-    "selected_match_fg": "#89878b"
+    "fg": "#89878b",
+    "match_fg": "#dc8a0e",
+    "selected_fg": "#6c696e",
+    "selected_match_fg": "#dc8a0e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#a7a5a8",
+    "layer0.tint": "#c4c3c5",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#4f4b51",
     "match_fg": "#dc8a0e",
-    "selected_fg": "transparent",
+    "selected_fg": "#322d34",
     "selected_match_fg": "#dc8a0e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#c4c3c5",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#c4c3c5",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#a7a5a8",
+    "layer0.tint": "#c4c3c5",
+    "color_scheme_tint": "#c4c3c5",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-unikitty-reversible.sublime-theme
+++ b/base16-unikitty-reversible.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#4b484e",
+    "layer1.tint": "#878589",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#878589",
+    "layer2.tint": "#69666b",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#878589",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#878589",
+    "layer0.tint": "#69666b",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c3c2c43f",
+    "layer0.tint": "#8785893f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e1e0e1",
     "match_fg": "#dc8a0e",
-    "selected_fg": "#a5a3a6",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#dc8a0e"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e1e0e1",
     "match_fg": "#dc8a0e",
-    "selected_fg": "#a5a3a6",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#dc8a0e"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e1e0e1",
-    "match_fg": "#c3c2c4",
-    "selected_fg": "#a5a3a6",
-    "selected_match_fg": "#a5a3a6"
+    "fg": "#a5a3a6",
+    "match_fg": "#dc8a0e",
+    "selected_fg": "#c3c2c4",
+    "selected_match_fg": "#dc8a0e"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#878589",
+    "layer0.tint": "#69666b",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e1e0e1",
     "match_fg": "#dc8a0e",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#dc8a0e",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#2e2a31",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#69666b",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#69666b",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#878589",
+    "layer0.tint": "#69666b",
+    "color_scheme_tint": "#69666b",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-uwunicorn.sublime-theme
+++ b/base16-uwunicorn.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2f2a3f",
+    "layer1.tint": "#6c3cb2",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6c3cb2",
+    "layer2.tint": "#46354a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6c3cb2",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6c3cb2",
+    "layer0.tint": "#46354a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#eed5d93f",
+    "layer0.tint": "#6c3cb23f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d9c2c6",
     "match_fg": "#a84a73",
-    "selected_fg": "#7e5f83",
+    "selected_fg": "#e4ccd0",
     "selected_match_fg": "#a84a73"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d9c2c6",
     "match_fg": "#a84a73",
-    "selected_fg": "#7e5f83",
+    "selected_fg": "#e4ccd0",
     "selected_match_fg": "#a84a73"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d9c2c6",
-    "match_fg": "#eed5d9",
-    "selected_fg": "#7e5f83",
-    "selected_match_fg": "#7e5f83"
+    "fg": "#7e5f83",
+    "match_fg": "#a84a73",
+    "selected_fg": "#eed5d9",
+    "selected_match_fg": "#a84a73"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6c3cb2",
+    "layer0.tint": "#46354a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d9c2c6",
     "match_fg": "#a84a73",
-    "selected_fg": "transparent",
+    "selected_fg": "#e4ccd0",
     "selected_match_fg": "#a84a73",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#241b26",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#46354a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#46354a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6c3cb2",
+    "layer0.tint": "#46354a",
+    "color_scheme_tint": "#46354a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-vesper.sublime-theme
+++ b/base16-vesper.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#232323",
+    "layer1.tint": "#333333",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#333333",
+    "layer2.tint": "#222222",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#333333",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b7b7b73f",
+    "layer0.tint": "#3333333f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c1c1c1",
     "match_fg": "#ffc799",
-    "selected_fg": "#999999",
+    "selected_fg": "#d5d5d5",
     "selected_match_fg": "#ffc799"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c1c1c1",
     "match_fg": "#ffc799",
-    "selected_fg": "#999999",
+    "selected_fg": "#d5d5d5",
     "selected_match_fg": "#ffc799"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c1c1c1",
-    "match_fg": "#b7b7b7",
-    "selected_fg": "#999999",
-    "selected_match_fg": "#999999"
+    "fg": "#999999",
+    "match_fg": "#ffc799",
+    "selected_fg": "#b7b7b7",
+    "selected_match_fg": "#ffc799"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c1c1c1",
     "match_fg": "#ffc799",
-    "selected_fg": "transparent",
+    "selected_fg": "#d5d5d5",
     "selected_match_fg": "#ffc799",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#101010",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#222222",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#333333",
+    "layer0.tint": "#222222",
+    "color_scheme_tint": "#222222",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-vice.sublime-theme
+++ b/base16-vice.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#22262d",
+    "layer1.tint": "#383a47",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#383a47",
+    "layer2.tint": "#3c3f4c",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#383a47",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#383a47",
+    "layer0.tint": "#3c3f4c",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8b9cbe3f",
+    "layer0.tint": "#383a473f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#b2bfd9",
     "match_fg": "#f0ffaa",
-    "selected_fg": "#555e70",
+    "selected_fg": "#f4f4f7",
     "selected_match_fg": "#f0ffaa"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#b2bfd9",
     "match_fg": "#f0ffaa",
-    "selected_fg": "#555e70",
+    "selected_fg": "#f4f4f7",
     "selected_match_fg": "#f0ffaa"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#b2bfd9",
-    "match_fg": "#8b9cbe",
-    "selected_fg": "#555e70",
-    "selected_match_fg": "#555e70"
+    "fg": "#555e70",
+    "match_fg": "#f0ffaa",
+    "selected_fg": "#8b9cbe",
+    "selected_match_fg": "#f0ffaa"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#383a47",
+    "layer0.tint": "#3c3f4c",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b2bfd9",
     "match_fg": "#f0ffaa",
-    "selected_fg": "transparent",
+    "selected_fg": "#f4f4f7",
     "selected_match_fg": "#f0ffaa",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#17191e",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3c3f4c",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3c3f4c",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#383a47",
+    "layer0.tint": "#3c3f4c",
+    "color_scheme_tint": "#3c3f4c",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-vulcan.sublime-theme
+++ b/base16-vulcan.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#122339",
+    "layer1.tint": "#7a5759",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#7a5759",
+    "layer2.tint": "#003552",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#7a5759",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#7a5759",
+    "layer0.tint": "#003552",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5b778c3f",
+    "layer0.tint": "#7a57593f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#333238",
     "match_fg": "#adb4b9",
-    "selected_fg": "#6b6977",
+    "selected_fg": "#214d68",
     "selected_match_fg": "#adb4b9"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#333238",
     "match_fg": "#adb4b9",
-    "selected_fg": "#6b6977",
+    "selected_fg": "#214d68",
     "selected_match_fg": "#adb4b9"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#333238",
-    "match_fg": "#5b778c",
-    "selected_fg": "#6b6977",
-    "selected_match_fg": "#6b6977"
+    "fg": "#6b6977",
+    "match_fg": "#adb4b9",
+    "selected_fg": "#5b778c",
+    "selected_match_fg": "#adb4b9"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#7a5759",
+    "layer0.tint": "#003552",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#333238",
     "match_fg": "#adb4b9",
-    "selected_fg": "transparent",
+    "selected_fg": "#214d68",
     "selected_match_fg": "#adb4b9",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#041523",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#003552",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#003552",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#7a5759",
+    "layer0.tint": "#003552",
+    "color_scheme_tint": "#003552",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-windows-10-light.sublime-theme
+++ b/base16-windows-10-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d9d9d9",
+    "layer0.tint": "#cccccc",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e5e5e51e",
+    "layer1.tint": "#cccccc",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#cccccc",
+    "layer2.tint": "#d9d9d9",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#cccccc",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#cccccc",
+    "layer0.tint": "#d9d9d9",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#7676761e",
+    "layer0.tint": "#cccccc1e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#414141",
+    "fg": "#767676",
     "match_fg": "#c19c00",
-    "selected_fg": "#ababab",
+    "selected_fg": "#767676",
     "selected_match_fg": "#c19c00"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#414141",
+    "fg": "#767676",
     "match_fg": "#c19c00",
-    "selected_fg": "#ababab",
+    "selected_fg": "#767676",
     "selected_match_fg": "#c19c00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#414141",
-    "match_fg": "#767676",
-    "selected_fg": "#ababab",
-    "selected_match_fg": "#ababab"
+    "fg": "#ababab",
+    "match_fg": "#c19c00",
+    "selected_fg": "#767676",
+    "selected_match_fg": "#c19c00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#cccccc",
+    "layer0.tint": "#d9d9d9",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#414141",
     "match_fg": "#c19c00",
-    "selected_fg": "transparent",
+    "selected_fg": "#0c0c0c",
     "selected_match_fg": "#c19c00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#f2f2f2",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d9d9d9",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d9d9d9",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#cccccc",
+    "layer0.tint": "#d9d9d9",
+    "color_scheme_tint": "#d9d9d9",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-windows-10.sublime-theme
+++ b/base16-windows-10.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2f2f2f",
+    "layer1.tint": "#767676",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#767676",
+    "layer2.tint": "#535353",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#767676",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#767676",
+    "layer0.tint": "#535353",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cccccc3f",
+    "layer0.tint": "#7676763f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dfdfdf",
     "match_fg": "#f9f1a5",
-    "selected_fg": "#b9b9b9",
+    "selected_fg": "#f2f2f2",
     "selected_match_fg": "#f9f1a5"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dfdfdf",
     "match_fg": "#f9f1a5",
-    "selected_fg": "#b9b9b9",
+    "selected_fg": "#f2f2f2",
     "selected_match_fg": "#f9f1a5"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dfdfdf",
-    "match_fg": "#cccccc",
-    "selected_fg": "#b9b9b9",
-    "selected_match_fg": "#b9b9b9"
+    "fg": "#b9b9b9",
+    "match_fg": "#f9f1a5",
+    "selected_fg": "#cccccc",
+    "selected_match_fg": "#f9f1a5"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#767676",
+    "layer0.tint": "#535353",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dfdfdf",
     "match_fg": "#f9f1a5",
-    "selected_fg": "transparent",
+    "selected_fg": "#f2f2f2",
     "selected_match_fg": "#f9f1a5",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#0c0c0c",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#535353",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#535353",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#767676",
+    "layer0.tint": "#535353",
+    "color_scheme_tint": "#535353",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-windows-95-light.sublime-theme
+++ b/base16-windows-95-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#c4c4c4",
+    "layer0.tint": "#a8a8a8",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e0e0e01e",
+    "layer1.tint": "#a8a8a8",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#a8a8a8",
+    "layer2.tint": "#c4c4c4",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#a8a8a8",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#a8a8a8",
+    "layer0.tint": "#c4c4c4",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5454541e",
+    "layer0.tint": "#a8a8a81e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#2a2a2a",
+    "fg": "#545454",
     "match_fg": "#a85400",
-    "selected_fg": "#7e7e7e",
+    "selected_fg": "#545454",
     "selected_match_fg": "#a85400"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#2a2a2a",
+    "fg": "#545454",
     "match_fg": "#a85400",
-    "selected_fg": "#7e7e7e",
+    "selected_fg": "#545454",
     "selected_match_fg": "#a85400"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#2a2a2a",
-    "match_fg": "#545454",
-    "selected_fg": "#7e7e7e",
-    "selected_match_fg": "#7e7e7e"
+    "fg": "#7e7e7e",
+    "match_fg": "#a85400",
+    "selected_fg": "#545454",
+    "selected_match_fg": "#a85400"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#a8a8a8",
+    "layer0.tint": "#c4c4c4",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#2a2a2a",
     "match_fg": "#a85400",
-    "selected_fg": "transparent",
+    "selected_fg": "#000000",
     "selected_match_fg": "#a85400",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fcfcfc",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#c4c4c4",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#c4c4c4",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#a8a8a8",
+    "layer0.tint": "#c4c4c4",
+    "color_scheme_tint": "#c4c4c4",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-windows-95.sublime-theme
+++ b/base16-windows-95.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1c1c1c",
+    "layer1.tint": "#545454",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#545454",
+    "layer2.tint": "#383838",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#545454",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#545454",
+    "layer0.tint": "#383838",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#a8a8a83f",
+    "layer0.tint": "#5454543f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d2d2d2",
     "match_fg": "#fcfc54",
-    "selected_fg": "#7e7e7e",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#fcfc54"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d2d2d2",
     "match_fg": "#fcfc54",
-    "selected_fg": "#7e7e7e",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#fcfc54"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d2d2d2",
-    "match_fg": "#a8a8a8",
-    "selected_fg": "#7e7e7e",
-    "selected_match_fg": "#7e7e7e"
+    "fg": "#7e7e7e",
+    "match_fg": "#fcfc54",
+    "selected_fg": "#a8a8a8",
+    "selected_match_fg": "#fcfc54"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#545454",
+    "layer0.tint": "#383838",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d2d2d2",
     "match_fg": "#fcfc54",
-    "selected_fg": "transparent",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#fcfc54",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#383838",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#383838",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#545454",
+    "layer0.tint": "#383838",
+    "color_scheme_tint": "#383838",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-windows-highcontrast-light.sublime-theme
+++ b/base16-windows-highcontrast-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d4d4d4",
+    "layer0.tint": "#c0c0c0",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#e8e8e81e",
+    "layer1.tint": "#c0c0c0",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#c0c0c0",
+    "layer2.tint": "#d4d4d4",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#c0c0c0",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#d4d4d4",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#5454541e",
+    "layer0.tint": "#c0c0c01e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#2a2a2a",
+    "fg": "#545454",
     "match_fg": "#808000",
-    "selected_fg": "#7e7e7e",
+    "selected_fg": "#545454",
     "selected_match_fg": "#808000"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#2a2a2a",
+    "fg": "#545454",
     "match_fg": "#808000",
-    "selected_fg": "#7e7e7e",
+    "selected_fg": "#545454",
     "selected_match_fg": "#808000"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#2a2a2a",
-    "match_fg": "#545454",
-    "selected_fg": "#7e7e7e",
-    "selected_match_fg": "#7e7e7e"
+    "fg": "#7e7e7e",
+    "match_fg": "#808000",
+    "selected_fg": "#545454",
+    "selected_match_fg": "#808000"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#d4d4d4",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#2a2a2a",
     "match_fg": "#808000",
-    "selected_fg": "transparent",
+    "selected_fg": "#000000",
     "selected_match_fg": "#808000",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#fcfcfc",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d4d4d4",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d4d4d4",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#d4d4d4",
+    "color_scheme_tint": "#d4d4d4",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-windows-highcontrast.sublime-theme
+++ b/base16-windows-highcontrast.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#1c1c1c",
+    "layer1.tint": "#545454",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#545454",
+    "layer2.tint": "#383838",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#545454",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#545454",
+    "layer0.tint": "#383838",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c0c0c03f",
+    "layer0.tint": "#5454543f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#dedede",
     "match_fg": "#fcfc54",
-    "selected_fg": "#a2a2a2",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#fcfc54"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#dedede",
     "match_fg": "#fcfc54",
-    "selected_fg": "#a2a2a2",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#fcfc54"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#dedede",
-    "match_fg": "#c0c0c0",
-    "selected_fg": "#a2a2a2",
-    "selected_match_fg": "#a2a2a2"
+    "fg": "#a2a2a2",
+    "match_fg": "#fcfc54",
+    "selected_fg": "#c0c0c0",
+    "selected_match_fg": "#fcfc54"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#545454",
+    "layer0.tint": "#383838",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#dedede",
     "match_fg": "#fcfc54",
-    "selected_fg": "transparent",
+    "selected_fg": "#fcfcfc",
     "selected_match_fg": "#fcfc54",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#383838",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#383838",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#545454",
+    "layer0.tint": "#383838",
+    "color_scheme_tint": "#383838",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-windows-nt-light.sublime-theme
+++ b/base16-windows-nt-light.sublime-theme
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#d5d5d5",
+    "layer0.tint": "#c0c0c0",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#eaeaea1e",
+    "layer1.tint": "#c0c0c0",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#c0c0c0",
+    "layer2.tint": "#d5d5d5",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#c0c0c0",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#d5d5d5",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#8080801e",
+    "layer0.tint": "#c0c0c01e",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#404040",
+    "fg": "#808080",
     "match_fg": "#808000",
-    "selected_fg": "#a0a0a0",
+    "selected_fg": "#808080",
     "selected_match_fg": "#808000"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#404040",
+    "fg": "#808080",
     "match_fg": "#808000",
-    "selected_fg": "#a0a0a0",
+    "selected_fg": "#808080",
     "selected_match_fg": "#808000"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#404040",
-    "match_fg": "#808080",
-    "selected_fg": "#a0a0a0",
-    "selected_match_fg": "#a0a0a0"
+    "fg": "#a0a0a0",
+    "match_fg": "#808000",
+    "selected_fg": "#808080",
+    "selected_match_fg": "#808000"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#d5d5d5",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#404040",
     "match_fg": "#808000",
-    "selected_fg": "transparent",
+    "selected_fg": "#000000",
     "selected_match_fg": "#808000",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#ffffff",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#d5d5d5",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#d5d5d5",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#c0c0c0",
+    "layer0.tint": "#d5d5d5",
+    "color_scheme_tint": "#d5d5d5",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-windows-nt.sublime-theme
+++ b/base16-windows-nt.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#2a2a2a",
+    "layer1.tint": "#808080",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#808080",
+    "layer2.tint": "#555555",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#808080",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#555555",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#c0c0c03f",
+    "layer0.tint": "#8080803f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#e0e0e0",
     "match_fg": "#ffff00",
-    "selected_fg": "#a1a1a1",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffff00"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#e0e0e0",
     "match_fg": "#ffff00",
-    "selected_fg": "#a1a1a1",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffff00"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#e0e0e0",
-    "match_fg": "#c0c0c0",
-    "selected_fg": "#a1a1a1",
-    "selected_match_fg": "#a1a1a1"
+    "fg": "#a1a1a1",
+    "match_fg": "#ffff00",
+    "selected_fg": "#c0c0c0",
+    "selected_match_fg": "#ffff00"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#808080",
+    "layer0.tint": "#555555",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#ffff00",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffff00",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#555555",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#555555",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#808080",
+    "layer0.tint": "#555555",
+    "color_scheme_tint": "#555555",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-woodland.sublime-theme
+++ b/base16-woodland.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#302b25",
+    "layer1.tint": "#9d8b70",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#9d8b70",
+    "layer2.tint": "#48413a",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#9d8b70",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#9d8b70",
+    "layer0.tint": "#48413a",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#cabcb13f",
+    "layer0.tint": "#9d8b703f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#d7c8bc",
     "match_fg": "#e0ac16",
-    "selected_fg": "#b4a490",
+    "selected_fg": "#e4d4c8",
     "selected_match_fg": "#e0ac16"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#d7c8bc",
     "match_fg": "#e0ac16",
-    "selected_fg": "#b4a490",
+    "selected_fg": "#e4d4c8",
     "selected_match_fg": "#e0ac16"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#d7c8bc",
-    "match_fg": "#cabcb1",
-    "selected_fg": "#b4a490",
-    "selected_match_fg": "#b4a490"
+    "fg": "#b4a490",
+    "match_fg": "#e0ac16",
+    "selected_fg": "#cabcb1",
+    "selected_match_fg": "#e0ac16"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#9d8b70",
+    "layer0.tint": "#48413a",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#d7c8bc",
     "match_fg": "#e0ac16",
-    "selected_fg": "transparent",
+    "selected_fg": "#e4d4c8",
     "selected_match_fg": "#e0ac16",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#231e18",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#48413a",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#48413a",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#9d8b70",
+    "layer0.tint": "#48413a",
+    "color_scheme_tint": "#48413a",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-xcode-dusk.sublime-theme
+++ b/base16-xcode-dusk.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#3d4048",
+    "layer1.tint": "#686a71",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#686a71",
+    "layer2.tint": "#53555d",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#686a71",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#686a71",
+    "layer0.tint": "#53555d",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#9395993f",
+    "layer0.tint": "#686a713f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#a9aaae",
     "match_fg": "#438288",
-    "selected_fg": "#7e8086",
+    "selected_fg": "#bebfc2",
     "selected_match_fg": "#438288"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#a9aaae",
     "match_fg": "#438288",
-    "selected_fg": "#7e8086",
+    "selected_fg": "#bebfc2",
     "selected_match_fg": "#438288"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#a9aaae",
-    "match_fg": "#939599",
-    "selected_fg": "#7e8086",
-    "selected_match_fg": "#7e8086"
+    "fg": "#7e8086",
+    "match_fg": "#438288",
+    "selected_fg": "#939599",
+    "selected_match_fg": "#438288"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#686a71",
+    "layer0.tint": "#53555d",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#a9aaae",
     "match_fg": "#438288",
-    "selected_fg": "transparent",
+    "selected_fg": "#bebfc2",
     "selected_match_fg": "#438288",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#282b35",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#53555d",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#53555d",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#686a71",
+    "layer0.tint": "#53555d",
+    "color_scheme_tint": "#53555d",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-zenbones.sublime-theme
+++ b/base16-zenbones.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#de6e7c",
+    "layer1.tint": "#b77e64",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#b77e64",
+    "layer2.tint": "#819b69",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#b77e64",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#b77e64",
+    "layer0.tint": "#819b69",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#b279a73f",
+    "layer0.tint": "#b77e643f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#66a5ad",
     "match_fg": "#8bae68",
-    "selected_fg": "#6099c0",
+    "selected_fg": "#bbbbbb",
     "selected_match_fg": "#8bae68"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#66a5ad",
     "match_fg": "#8bae68",
-    "selected_fg": "#6099c0",
+    "selected_fg": "#bbbbbb",
     "selected_match_fg": "#8bae68"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#66a5ad",
-    "match_fg": "#b279a7",
-    "selected_fg": "#6099c0",
-    "selected_match_fg": "#6099c0"
+    "fg": "#6099c0",
+    "match_fg": "#8bae68",
+    "selected_fg": "#b279a7",
+    "selected_match_fg": "#8bae68"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#b77e64",
+    "layer0.tint": "#819b69",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#66a5ad",
     "match_fg": "#8bae68",
-    "selected_fg": "transparent",
+    "selected_fg": "#bbbbbb",
     "selected_match_fg": "#8bae68",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#191919",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#819b69",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#819b69",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#b77e64",
+    "layer0.tint": "#819b69",
+    "color_scheme_tint": "#819b69",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base16-zenburn.sublime-theme
+++ b/base16-zenburn.sublime-theme
@@ -558,12 +558,12 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#404040",
+    "layer1.tint": "#6f6f6f",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#6f6f6f",
+    "layer2.tint": "#606060",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#6f6f6f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#6f6f6f",
+    "layer0.tint": "#606060",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#dcdccc3f",
+    "layer0.tint": "#6f6f6f3f",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -628,7 +622,7 @@
     "class": "quick_panel_label",
     "fg": "#c0c0c0",
     "match_fg": "#e0cf9f",
-    "selected_fg": "#808080",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e0cf9f"
   },
   {
@@ -636,15 +630,15 @@
     "parents": [{ "class": "overlay_control" }],
     "fg": "#c0c0c0",
     "match_fg": "#e0cf9f",
-    "selected_fg": "#808080",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e0cf9f"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#c0c0c0",
-    "match_fg": "#dcdccc",
-    "selected_fg": "#808080",
-    "selected_match_fg": "#808080"
+    "fg": "#808080",
+    "match_fg": "#e0cf9f",
+    "selected_fg": "#dcdccc",
+    "selected_match_fg": "#e0cf9f"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#6f6f6f",
+    "layer0.tint": "#606060",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#c0c0c0",
     "match_fg": "#e0cf9f",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#e0cf9f",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#383838",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#606060",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#606060",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#6f6f6f",
+    "layer0.tint": "#606060",
+    "color_scheme_tint": "#606060",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-brogrammer.sublime-theme
+++ b/base24-brogrammer.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#1f1f1f",
+    "layer1.tint": "#343d50",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#1f1f1f",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#1f1f1f",
+    "layer0.tint": "#2a3141",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#d6dae4",
-    "match_fg": "#524fb9",
-    "selected_fg": "#c1c8d7",
-    "selected_match_fg": "#524fb9"
+    "fg": "#e3e6ed",
+    "match_fg": "#0f80d5",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#0f80d5"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#d6dae4",
-    "match_fg": "#524fb9",
-    "selected_fg": "#c1c8d7",
-    "selected_match_fg": "#524fb9"
+    "fg": "#e3e6ed",
+    "match_fg": "#0f80d5",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#0f80d5"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#d6dae4",
-    "match_fg": "#c1c8d7",
-    "selected_fg": "#343d50",
-    "selected_match_fg": "#c1c8d7" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#0f80d5",
+    "selected_fg": "#c1c8d7",
+    "selected_match_fg": "#0f80d5"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e3e6ed",
     "match_fg": "#524fb9",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#524fb9",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#131313",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2a3141",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2a3141",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#2a3141",
+    "color_scheme_tint": "#2a3141",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-chalk.sublime-theme
+++ b/base24-chalk.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#202020",
+    "layer1.tint": "#505050",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#202020",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#202020",
+    "layer0.tint": "#303030",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#b0b0b0",
-    "match_fg": "#e1a3ee",
-    "selected_fg": "#d0d0d0",
-    "selected_match_fg": "#e1a3ee"
+    "fg": "#e0e0e0",
+    "match_fg": "#ddb26f",
+    "selected_fg": "#f5f5f5",
+    "selected_match_fg": "#ddb26f"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#b0b0b0",
-    "match_fg": "#e1a3ee",
-    "selected_fg": "#d0d0d0",
-    "selected_match_fg": "#e1a3ee"
+    "fg": "#e0e0e0",
+    "match_fg": "#ddb26f",
+    "selected_fg": "#f5f5f5",
+    "selected_match_fg": "#ddb26f"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#b0b0b0",
-    "match_fg": "#d0d0d0",
-    "selected_fg": "#505050",
-    "selected_match_fg": "#d0d0d0" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#ddb26f",
+    "selected_fg": "#d0d0d0",
+    "selected_match_fg": "#ddb26f"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e0e0e0",
     "match_fg": "#e1a3ee",
-    "selected_fg": "transparent",
+    "selected_fg": "#f5f5f5",
     "selected_match_fg": "#e1a3ee",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#151515",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#303030",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#303030",
+    "color_scheme_tint": "#303030",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-dracula.sublime-theme
+++ b/base24-dracula.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#282a36",
+    "layer1.tint": "#4d4f68",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#282a36",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#282a36",
+    "layer0.tint": "#3a3c4e",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#626483",
-    "match_fg": "#ff92df",
-    "selected_fg": "#e9e9f4",
-    "selected_match_fg": "#ff92df"
+    "fg": "#f8f8f2",
+    "match_fg": "#ebff87",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#ebff87"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#626483",
-    "match_fg": "#ff92df",
-    "selected_fg": "#e9e9f4",
-    "selected_match_fg": "#ff92df"
+    "fg": "#f8f8f2",
+    "match_fg": "#ebff87",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#ebff87"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#626483",
-    "match_fg": "#e9e9f4",
-    "selected_fg": "#4d4f68",
-    "selected_match_fg": "#e9e9f4" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#ebff87",
+    "selected_fg": "#e9e9f4",
+    "selected_match_fg": "#ebff87"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f8f8f2",
     "match_fg": "#ff92df",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ff92df",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#21222c",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#3a3c4e",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#3a3c4e",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#3a3c4e",
+    "color_scheme_tint": "#3a3c4e",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-espresso.sublime-theme
+++ b/base24-espresso.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#343434",
+    "layer1.tint": "#797979",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#343434",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#343434",
+    "layer0.tint": "#535353",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#a0a09f",
-    "match_fg": "#efb5f7",
-    "selected_fg": "#c7c7c5",
-    "selected_match_fg": "#efb5f7"
+    "fg": "#eeeeec",
+    "match_fg": "#8ab7d9",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#8ab7d9"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#a0a09f",
-    "match_fg": "#efb5f7",
-    "selected_fg": "#c7c7c5",
-    "selected_match_fg": "#efb5f7"
+    "fg": "#eeeeec",
+    "match_fg": "#8ab7d9",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#8ab7d9"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#a0a09f",
-    "match_fg": "#c7c7c5",
-    "selected_fg": "#797979",
-    "selected_match_fg": "#c7c7c5" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#8ab7d9",
+    "selected_fg": "#c7c7c5",
+    "selected_match_fg": "#8ab7d9"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#eeeeec",
     "match_fg": "#efb5f7",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#efb5f7",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#262626",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#535353",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#535353",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#535353",
+    "color_scheme_tint": "#535353",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-flat.sublime-theme
+++ b/base24-flat.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#1d2845",
+    "layer1.tint": "#444e5b",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#1d2845",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#1d2845",
+    "layer0.tint": "#2e2e45",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#68717b",
-    "match_fg": "#8230a7",
-    "selected_fg": "#8c939a",
-    "selected_match_fg": "#8230a7"
+    "fg": "#b0b6ba",
+    "match_fg": "#3c7dd2",
+    "selected_fg": "#e7eced",
+    "selected_match_fg": "#3c7dd2"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#68717b",
-    "match_fg": "#8230a7",
-    "selected_fg": "#8c939a",
-    "selected_match_fg": "#8230a7"
+    "fg": "#b0b6ba",
+    "match_fg": "#3c7dd2",
+    "selected_fg": "#e7eced",
+    "selected_match_fg": "#3c7dd2"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#68717b",
-    "match_fg": "#8c939a",
-    "selected_fg": "#444e5b",
-    "selected_match_fg": "#8c939a" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#3c7dd2",
+    "selected_fg": "#8c939a",
+    "selected_match_fg": "#3c7dd2"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#b0b6ba",
     "match_fg": "#8230a7",
-    "selected_fg": "transparent",
+    "selected_fg": "#e7eced",
     "selected_match_fg": "#8230a7",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#082845",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#2e2e45",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#2e2e45",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#2e2e45",
+    "color_scheme_tint": "#2e2e45",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-framer.sublime-theme
+++ b/base24-framer.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#141414",
+    "layer1.tint": "#636363",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#141414",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#141414",
+    "layer0.tint": "#414141",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#868686",
-    "match_fg": "#cebbff",
-    "selected_fg": "#a9a9a9",
-    "selected_match_fg": "#cebbff"
+    "fg": "#cccccc",
+    "match_fg": "#33bbff",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#33bbff"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#868686",
-    "match_fg": "#cebbff",
-    "selected_fg": "#a9a9a9",
-    "selected_match_fg": "#cebbff"
+    "fg": "#cccccc",
+    "match_fg": "#33bbff",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#33bbff"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#868686",
-    "match_fg": "#a9a9a9",
-    "selected_fg": "#636363",
-    "selected_match_fg": "#a9a9a9" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#33bbff",
+    "selected_fg": "#a9a9a9",
+    "selected_match_fg": "#33bbff"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cccccc",
     "match_fg": "#cebbff",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#cebbff",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#111111",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#414141",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#414141",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#414141",
+    "color_scheme_tint": "#414141",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-github.sublime-theme
+++ b/base24-github.sublime-theme
@@ -552,12 +552,12 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#666666",
+    "layer0.tint": "#8c8c8c",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#3e3e3e",
+    "layer1.tint": "#8c8c8c",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#3e3e3e",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#3e3e3e",
+    "layer0.tint": "#666666",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#b2b2b2",
-    "match_fg": "#ffa29f",
-    "selected_fg": "#d8d8d8",
-    "selected_match_fg": "#ffa29f"
+    "fg": "#ffffff",
+    "match_fg": "#2e6cba",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#2e6cba"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#b2b2b2",
-    "match_fg": "#ffa29f",
-    "selected_fg": "#d8d8d8",
-    "selected_match_fg": "#ffa29f"
+    "fg": "#ffffff",
+    "match_fg": "#2e6cba",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#2e6cba"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#b2b2b2",
-    "match_fg": "#d8d8d8",
-    "selected_fg": "#8c8c8c",
-    "selected_match_fg": "#d8d8d8" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#2e6cba",
+    "selected_fg": "#d8d8d8",
+    "selected_match_fg": "#2e6cba"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#ffffff",
     "match_fg": "#ffa29f",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#ffa29f",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#f4f4f4",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#666666",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#666666",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#666666",
+    "color_scheme_tint": "#666666",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-hardcore.sublime-theme
+++ b/base24-hardcore.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#141414",
+    "layer1.tint": "#636363",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#141414",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#141414",
+    "layer0.tint": "#414141",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#868686",
-    "match_fg": "#cebbff",
-    "selected_fg": "#a9a9a9",
-    "selected_match_fg": "#cebbff"
+    "fg": "#cccccc",
+    "match_fg": "#33bbff",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#33bbff"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#868686",
-    "match_fg": "#cebbff",
-    "selected_fg": "#a9a9a9",
-    "selected_match_fg": "#cebbff"
+    "fg": "#cccccc",
+    "match_fg": "#33bbff",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#33bbff"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#868686",
-    "match_fg": "#a9a9a9",
-    "selected_fg": "#636363",
-    "selected_match_fg": "#a9a9a9" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#33bbff",
+    "selected_fg": "#a9a9a9",
+    "selected_match_fg": "#33bbff"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#cccccc",
     "match_fg": "#cebbff",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#cebbff",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#111111",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#414141",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#414141",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#414141",
+    "color_scheme_tint": "#414141",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-one-black.sublime-theme
+++ b/base24-one-black.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#000000",
+    "layer1.tint": "#545862",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#000000",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#000000",
+    "layer0.tint": "#4f5666",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#9196a1",
-    "match_fg": "#de73ff",
-    "selected_fg": "#abb2bf",
-    "selected_match_fg": "#de73ff"
+    "fg": "#e6e6e6",
+    "match_fg": "#e6b965",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#e6b965"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#9196a1",
-    "match_fg": "#de73ff",
-    "selected_fg": "#abb2bf",
-    "selected_match_fg": "#de73ff"
+    "fg": "#e6e6e6",
+    "match_fg": "#e6b965",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#e6b965"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#9196a1",
-    "match_fg": "#abb2bf",
-    "selected_fg": "#545862",
-    "selected_match_fg": "#abb2bf" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#e6b965",
+    "selected_fg": "#abb2bf",
+    "selected_match_fg": "#e6b965"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e6e6e6",
     "match_fg": "#de73ff",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#de73ff",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#000000",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4f5666",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4f5666",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#4f5666",
+    "color_scheme_tint": "#4f5666",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-one-dark.sublime-theme
+++ b/base24-one-dark.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#3f4451",
+    "layer1.tint": "#545862",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#3f4451",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#3f4451",
+    "layer0.tint": "#4f5666",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#9196a1",
-    "match_fg": "#de73ff",
-    "selected_fg": "#abb2bf",
-    "selected_match_fg": "#de73ff"
+    "fg": "#e6e6e6",
+    "match_fg": "#e6b965",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#e6b965"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#9196a1",
-    "match_fg": "#de73ff",
-    "selected_fg": "#abb2bf",
-    "selected_match_fg": "#de73ff"
+    "fg": "#e6e6e6",
+    "match_fg": "#e6b965",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#e6b965"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#9196a1",
-    "match_fg": "#abb2bf",
-    "selected_fg": "#545862",
-    "selected_match_fg": "#abb2bf" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#e6b965",
+    "selected_fg": "#abb2bf",
+    "selected_match_fg": "#e6b965"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#e6e6e6",
     "match_fg": "#de73ff",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#de73ff",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#282c34",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#4f5666",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#4f5666",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#4f5666",
+    "color_scheme_tint": "#4f5666",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-one-light.sublime-theme
+++ b/base24-one-light.sublime-theme
@@ -552,12 +552,12 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#cacace",
+    "layer0.tint": "#a0a1a7",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#dfdfe1",
+    "layer1.tint": "#a0a1a7",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#dfdfe1",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#dfdfe1",
+    "layer0.tint": "#cacace",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#696c77",
-    "match_fg": "#d02fcd",
-    "selected_fg": "#383a42",
-    "selected_match_fg": "#d02fcd"
+    "fg": "#202227",
+    "match_fg": "#febb2a",
+    "selected_fg": "#090a0b",
+    "selected_match_fg": "#febb2a"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#696c77",
-    "match_fg": "#d02fcd",
-    "selected_fg": "#383a42",
-    "selected_match_fg": "#d02fcd"
+    "fg": "#202227",
+    "match_fg": "#febb2a",
+    "selected_fg": "#090a0b",
+    "selected_match_fg": "#febb2a"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#696c77",
-    "match_fg": "#383a42",
-    "selected_fg": "#a0a1a7",
-    "selected_match_fg": "#383a42" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#febb2a",
+    "selected_fg": "#383a42",
+    "selected_match_fg": "#febb2a"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#202227",
     "match_fg": "#d02fcd",
-    "selected_fg": "transparent",
+    "selected_fg": "#090a0b",
     "selected_match_fg": "#d02fcd",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#e7e7e9",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#cacace",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#cacace",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#cacace",
+    "color_scheme_tint": "#cacace",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/base24-sparky.sublime-theme
+++ b/base24-sparky.sublime-theme
@@ -557,7 +557,7 @@
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#00313c",
+    "layer1.tint": "#003b49",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#00313c",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#00313c",
+    "layer0.tint": "#003c46",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#00778b",
-    "match_fg": "#f99fc9",
-    "selected_fg": "#f4f5f0",
-    "selected_match_fg": "#f99fc9"
+    "fg": "#f5f5f1",
+    "match_fg": "#fbdd40",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#fbdd40"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#00778b",
-    "match_fg": "#f99fc9",
-    "selected_fg": "#f4f5f0",
-    "selected_match_fg": "#f99fc9"
+    "fg": "#f5f5f1",
+    "match_fg": "#fbdd40",
+    "selected_fg": "#ffffff",
+    "selected_match_fg": "#fbdd40"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#00778b",
-    "match_fg": "#f4f5f0",
-    "selected_fg": "#003b49",
-    "selected_match_fg": "#f4f5f0" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#"
+    "match_fg": "#fbdd40",
+    "selected_fg": "#f4f5f0",
+    "selected_match_fg": "#fbdd40"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#f5f5f1",
     "match_fg": "#f99fc9",
-    "selected_fg": "transparent",
+    "selected_fg": "#ffffff",
     "selected_match_fg": "#f99fc9",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#072b31",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#003c46",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#003c46",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#003c46",
+    "color_scheme_tint": "#003c46",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/templates/base16-sublime-theme.mustache
+++ b/templates/base16-sublime-theme.mustache
@@ -553,17 +553,17 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#{{base02-hex}}",
+    "layer0.tint": "{{#scheme-is-light-variant}}#{{base03-hex}}{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}#{{base02-hex}}{{/scheme-is-light-variant}}",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint": "#{{base01-hex}}{{#scheme-is-light-variant}}1e{{/scheme-is-light-variant}}",
+    "layer1.tint": "#{{base03-hex}}",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
     "layer2.opacity": 1.0,
-    "layer2.tint": "#{{base03-hex}}",
+    "layer2.tint": "#{{base02-hex}}",
 
     "content_margin": [10, 35, 10, 20]
   },
@@ -571,15 +571,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#{{base03-hex}}",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#{{base03-hex}}",
+    "layer0.tint": "#{{base02-hex}}",
     "layer0.opacity": 1.0
   },
 
@@ -607,7 +601,7 @@
   {
     "class": "quick_panel_row",
     "layer0.texture": "tinted_theming/assets/tree-highlight.png",
-    "layer0.tint": "#{{base05-hex}}{{#scheme-is-light-variant}}1e{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}3f{{/scheme-is-light-variant}}",
+    "layer0.tint": "#{{base03-hex}}{{#scheme-is-light-variant}}1e{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}3f{{/scheme-is-light-variant}}",
     "layer0.inner_margin": [8, 4],
     "layer0.opacity": 0,
 
@@ -626,25 +620,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#{{base06-hex}}",
+    "fg": "{{#scheme-is-light-variant}}#{{base05-hex}}{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}#{{base06-hex}}{{/scheme-is-light-variant}}",
     "match_fg": "#{{base0A-hex}}",
-    "selected_fg": "#{{base04-hex}}",
+    "selected_fg": "{{#scheme-is-light-variant}}#{{base05-hex}}{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}#{{base07-hex}}{{/scheme-is-light-variant}}",
     "selected_match_fg": "#{{base0A-hex}}"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#{{base06-hex}}",
+    "fg": "{{#scheme-is-light-variant}}#{{base05-hex}}{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}#{{base06-hex}}{{/scheme-is-light-variant}}",
     "match_fg": "#{{base0A-hex}}",
-    "selected_fg": "#{{base04-hex}}",
+    "selected_fg": "{{#scheme-is-light-variant}}#{{base05-hex}}{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}#{{base07-hex}}{{/scheme-is-light-variant}}",
     "selected_match_fg": "#{{base0A-hex}}"
   },
   {
     "class": "quick_panel_path_label",
-    "fg": "#{{base06-hex}}",
-    "match_fg": "#{{base05-hex}}",
-    "selected_fg": "#{{base04-hex}}",
-    "selected_match_fg": "#{{base04-hex}}"
+    "fg": "#{{base04-hex}}",
+    "match_fg": "#{{base0A-hex}}",
+    "selected_fg": "#{{base05-hex}}",
+    "selected_match_fg": "#{{base0A-hex}}"
   },
   {
     "class": "quick_panel_detail_label",
@@ -726,7 +720,7 @@
     "layer0.texture": "tinted_theming/assets/popup-bg.png",
     "layer0.inner_margin": [4, 4, 4, 4],
     "layer0.opacity": 1,
-    "layer0.tint": "#{{base03-hex}}",
+    "layer0.tint": "#{{base02-hex}}",
 
     "content_margin": [0, 4]
   },
@@ -757,9 +751,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#{{base06-hex}}",
     "match_fg": "#{{base0A-hex}}",
-    "selected_fg": "transparent",
+    "selected_fg": "#{{base07-hex}}",
     "selected_match_fg": "#{{base0A-hex}}",
     "fg_blend": true
   },
@@ -1211,6 +1205,18 @@
     "layer0.tint": "#{{base00-hex}}",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#{{base02-hex}}",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#{{base02-hex}}",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,7 +1275,8 @@
     "layer0.texture": "tinted_theming/assets/input-bg.png",
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
-    "layer0.tint": "#{{base03-hex}}",
+    "layer0.tint": "#{{base02-hex}}",
+    "color_scheme_tint": "#{{base02-hex}}",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,

--- a/templates/base24-sublime-theme.mustache
+++ b/templates/base24-sublime-theme.mustache
@@ -552,12 +552,12 @@
     "layer0.texture": "tinted_theming/assets/overlay-shadow.png",
     "layer0.inner_margin": [15, 35, 15, 25],
     "layer0.opacity": 1,
-    "layer0.tint": "#{{base02-hex}}",
+    "layer0.tint": "{{#scheme-is-light-variant}}#{{base03-hex}}{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}#{{base02-hex}}{{/scheme-is-light-variant}}",
 
     "layer1.texture": "tinted_theming/assets/overlay-border.png",
     "layer1.inner_margin": [15, 35, 15, 25],
     "layer1.opacity": 1.0,
-    "layer1.tint":  "#{{base01-hex}}",
+    "layer1.tint": "#{{base03-hex}}",
 
     "layer2.texture": "tinted_theming/assets/overlay-bg.png",
     "layer2.inner_margin": [15, 35, 15, 25],
@@ -570,15 +570,9 @@
 
   {
     "class": "quick_panel",
-    "row_padding": [13, 7],
-    "layer0.tint": "#{{base01-hex}}",
-    "layer0.opacity": 1.0
-  },
-  {
-    "class": "quick_panel",
     "parents": [{ "class": "overlay_control" }],
     "row_padding": [13, 7],
-    "layer0.tint": "#{{base01-hex}}",
+    "layer0.tint": "#{{base02-hex}}",
     "layer0.opacity": 1.0
   },
 
@@ -625,29 +619,25 @@
 
   {
     "class": "quick_panel_label",
-    "fg": "#{{base04-hex}}",
-    "match_fg": "#{{base17-hex}}",
-    "selected_fg": "#{{base05-hex}}",
-    "selected_match_fg": "#{{base17-hex}}"
+    "fg": "#{{base06-hex}}",
+    "match_fg": "#{{base0A-hex}}",
+    "selected_fg": "#{{base07-hex}}",
+    "selected_match_fg": "#{{base0A-hex}}"
   },
   {
     "class": "quick_panel_label",
     "parents": [{ "class": "overlay_control" }],
-    "fg": "#{{base04-hex}}",
-    "match_fg": "#{{base17-hex}}",
-    "selected_fg": "#{{base05-hex}}",
-    "selected_match_fg": "#{{base17-hex}}"
+    "fg": "#{{base06-hex}}",
+    "match_fg": "#{{base0A-hex}}",
+    "selected_fg": "#{{base07-hex}}",
+    "selected_match_fg": "#{{base0A-hex}}"
   },
   {
     "class": "quick_panel_path_label",
     "fg": "#{{base04-hex}}",
-    "match_fg": "#{{base05-hex}}",
-    "selected_fg": "#{{base03-hex}}",
-    "selected_match_fg": "#{{base05-hex}}" 
-  },
-  {
-    "class": "quick_panel_detail_label",
-    "link_color": "#{{base0D}}"
+    "match_fg": "#{{base0A-hex}}",
+    "selected_fg": "#{{base05-hex}}",
+    "selected_match_fg": "#{{base0A-hex}}"
   },
 
 
@@ -756,9 +746,9 @@
 
   {
     "class": "auto_complete_label",
-    "fg": "transparent",
+    "fg": "#{{base06-hex}}",
     "match_fg": "#{{base17-hex}}",
-    "selected_fg": "transparent",
+    "selected_fg": "#{{base07-hex}}",
     "selected_match_fg": "#{{base17-hex}}",
     "fg_blend": true
   },
@@ -1210,6 +1200,18 @@
     "layer0.tint": "#{{base00-hex}}",
     "layer0.opacity": 1.0
   },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "overlay_control" }],
+    "layer0.tint": "#{{base02-hex}}",
+    "layer0.opacity": 1.0
+  },
+  {
+    "class": "scroll_track_control",
+    "parents" : [{ "class": "popup_control" }],
+    "layer0.tint": "#{{base02-hex}}",
+    "layer0.opacity": 1.0
+  },
 
 
   {
@@ -1269,6 +1271,7 @@
     "layer0.opacity": 1,
     "layer0.inner_margin": [10, 8],
     "layer0.tint": "#{{base02-hex}}",
+    "color_scheme_tint": "#{{base02-hex}}",
 
     "layer1.texture": "tinted_theming/assets/input-border.png",
     "layer1.opacity": 1,


### PR DESCRIPTION
I couldn't find the quickswitch popup, but I think it should be styled correctly now. I'm not able to figure out how to style the input and input placeholder text. You can see the text `Open files and folders` is hard to see in the find/replace dialog. I don't think it's a big deal but would be good to fix at some point. https://github.com/tinted-theming/tinted-sublime-text/issues/4

![image](https://github.com/user-attachments/assets/edf022dd-f8e1-4bef-aea7-01972265b319)

![image](https://github.com/user-attachments/assets/4a286b0b-48a8-426a-bc83-cd2b0b1541ca)
