### PR TITLE
Fix bug where base16 and base24 code editor backgrounds aren't base00

### DIFF
--- a/templates/base16-color-scheme.mustache
+++ b/templates/base16-color-scheme.mustache
@@ -2,7 +2,7 @@
   "name": "{{scheme-name}}",
 
   "globals": {
-    "background": "#{{base01-hex}}",
+    "background": "#{{base00-hex}}",
     "foreground": "#{{base05-hex}}",
     "invisibles": "#{{base04-hex}}99",
     "caret": "#{{base0A-hex}}",

--- a/templates/base24-color-scheme.mustache
+++ b/templates/base24-color-scheme.mustache
@@ -2,7 +2,7 @@
   "name": "{{scheme-name}}",
 
   "globals": {
-    "background": "#{{base01-hex}}",
+    "background": "#{{base00-hex}}",
     "foreground": "#{{base05-hex}}",
     "invisibles": "#{{base04-hex}}99",
     "caret": "#{{base17-hex}}",


### PR DESCRIPTION
Fixes https://github.com/tinted-theming/tinted-sublime-text/issues/9